### PR TITLE
docs: add vscode-vue-i18n-ally in vue-i18n section

### DIFF
--- a/docs/guide/ecosystem/i18n.md
+++ b/docs/guide/ecosystem/i18n.md
@@ -28,6 +28,11 @@ Vue I18n can be used inside Vue files as well as outside, in Router guards or Vu
 * [from internationalization (i18n) to localization (l10n) and back again](https://medium.com/@jamuhl/vue-js-from-internationalization-i18n-to-localization-l10n-and-back-again-c3e5f7cc5e71)
 
 </useful-links-section>
+<useful-links-section title="Tools">
+
+* [VSCode extension - Vue i18n Ally](https://github.com/antfu/vue-i18n-ally)
+
+</useful-links-section>
 </useful-links>
 
 ## Vuex-I18n


### PR DESCRIPTION
🌍[Vue i18n Ally](https://github.com/antfu/vue-i18n-ally) is a VSCode extension for better Vue-i18n experience.

It provides i18n keys annotation, autocomplete, auto-translating and more. 

Hopes I did the format right. Thanks!