### PR TITLE
Casing and typo tweaks

### DIFF
--- a/docs/guide/community/job-market.md
+++ b/docs/guide/community/job-market.md
@@ -27,7 +27,7 @@ A significant percentage of the income is distributed to the authors of both Vue
 </useful-links-section>
 </useful-links>
 
-## Other platforms
+## Other Platforms
 
 ### StackOverflow
 [Stack overflow](https://stackoverflow.com/jobs/developer-jobs-using-vuejs) has an active jobs section and it has been getting an increase of Vue related job offers lately. 
@@ -35,11 +35,11 @@ A significant percentage of the income is distributed to the authors of both Vue
 ### JSRemotely
 [JS Remotely](https://jsremotely.com/) includes Vue.js among its filters. There should be a new job post around once a week with various seniority level.
 
-## What skills are employers looking for in Vue Developers
+## What Skills are Employers Looking for in Vue Developers
 
 > Some explanation on what is most commonly searched for by employers when looking for Vue developers. Common pitfalls. This section should provide a general overview and leave the individual cases for the next one.
 
-## Tips from the employers' side
+## Tips from the Employers' Side
 
 The guidelines listed in this section come from actual Human Resources workers or Vue.js developers who take active part in the recruitment process in their respective companies. Unlike the summary above, these tips come from individual experiences and should be treated as such. 
 
@@ -67,6 +67,6 @@ I advice you to apply for a position, even if you don't cover all the points. De
   
 A few general advices wen applying to any job ad:
 
-  - Dont answer interview questions with just one word. Explain very briefly why you chose that answer.
+  - Don't answer interview questions with just one word. Explain very briefly why you chose that answer.
   - If a project is still in discussion phase, you can steer towards using Vue as a framework by showcasing usage examples and it's benefits.
   - Do some research about the company. Does it use Vue for other projects. Does it contribute to Open Source libraries. Does it boast a healthy working environment.

--- a/docs/guide/community/social-media.md
+++ b/docs/guide/community/social-media.md
@@ -70,7 +70,7 @@ If you want your new resource covered in the upcoming edition, submit it using t
 
 [VuePeople.org](https://vuepeople.org) is an interactive map of Vue.js developers and enthusiasts around the world, with a possibility to filter them with tags. The plan for the future is to make it network that connects the Vue.JS community not only with each other, but also with events and work opportunities. You can register via your Github account.
 
-## Influential people on Twitter
+## Influential People on Twitter
 
 Twitter is the first place where developers share updates on their packages, discuss ideas, point out findings, do polls or just ask for advice. 
  
@@ -83,7 +83,7 @@ Twitter is the first place where developers share updates on their packages, dis
 </useful-links-section>
 </useful-links>
 
-## Other platforms
+## Other Platforms
 
 As the Vue community continues to grow, there are more and more specialized groups appearing on various social platforms. We list some of them below, together with Vue-related groups in other services.
 
@@ -149,6 +149,6 @@ As the Vue community continues to grow, there are more and more specialized grou
 </useful-links-section>
 </useful-links>
 
-## Other language media
+## Other Language Media
 
 Not all of the Vue ecosystem around the world communicates in English. There are multiple other language groups on different platforms. You can find the most popular among them on [awesome-vue](https://github.com/vuejs/awesome-vue#community) repository.

--- a/docs/guide/ecosystem/client-server-communication.md
+++ b/docs/guide/ecosystem/client-server-communication.md
@@ -2,7 +2,7 @@
 
 When working with SPA's it is very common to fetch data from remote services. This allows for dynamic content to be displayed depending on certain applied criteria. Fetching of said data can be done in many ways, some of which are described below.
 
-## Ajax requests
+## Ajax Requests
 
 Ajax requests to REST API's are the most common way of fetching data asynchronously from remote services. Requests are sent to a server, where data is processed. In the meantime, depending on the implementation, we can either have a callback based approach or the newer Promise based one, where we can wait until the process either succeeds or errors out.
 
@@ -58,7 +58,7 @@ Fetch is a newer Promise based API that is integrated into [modern Browsers](htt
 
 You can also import a library like `isomorphic-fetch` for using fetch in Node.js environment, where it is not available.
 
-To use it with Vue, you dont need plugins, you can just import `fetch` and start working.
+To use it with Vue, you don't need plugins, you can just import `fetch` and start working.
 
 <useful-links>
 <useful-links-section title="Tutorials">

--- a/docs/guide/ecosystem/documentation.md
+++ b/docs/guide/ecosystem/documentation.md
@@ -1,10 +1,10 @@
-# Documentation platforms
+# Documentation Platforms
 
 Documentation is a very important part of any software, especially if it is going to be used by more than one developer.
 
 There are a few ways to document software, one is directly inside the code via comments and type declarations, while the other is using external documentation sources, from files (usually .md) inside project to full blown websites.
 
-## Documentation websites
+## Documentation Websites
 
 When choosing a platform to write your docs on, think about your priorities and preferences.
 
@@ -92,7 +92,7 @@ Here are the answers from the above questions:
 </useful-links-section>
 </useful-links>
 
-## Other website doc platforms
+## Other Website Doc Platforms
 
 Below is a list of popular documentation generators, that are not connected to Vue.
 
@@ -110,7 +110,7 @@ Below is a list of popular documentation generators, that are not connected to V
 </useful-links-section>
 </useful-links>
 
-## Component workbenches
+## Component Workbenches
 
 A workbench is a development environment for UI components. It allows developers to setup interactive examples of how a UI component can be used. One can setup a live demo of a Vue component by passing different props to it. Perfect to show your designer or for you to test the result of your work
 
@@ -179,7 +179,7 @@ storiesOf('Button', module)
 [Vue-styleguidist](https://github.com/vue-styleguidist/vue-styleguidist) is a port of [react-styleguidist](https://github.com/styleguidist/react-styleguidist) for vue components.
 You are building a Design System. You want a site to showcase your components, this should be your first choice.
 
-#### Documentation style
+#### Documentation Style
 
 Styleguidist uses standard JSDoc comments to extract useful meta data from components.
 
@@ -273,7 +273,7 @@ Here give a reason for using the component. The code samples are going to be ren
 [Vuese](https://github.com/vuese/vuese) is documentation oriented. It sacrifices interactivity to be more integrable.
 If you have to generate your doc to integrate it in a bigger one, this is the workbench that you want. Without sacrificing the Hot Module Reload, it generates a good looking static doc.
 
-#### Documentation style
+#### Documentation Style
 
 Vuese uses its own documentation format, more compact than JSDoc.
 

--- a/docs/guide/ecosystem/editors-and-tools.md
+++ b/docs/guide/ecosystem/editors-and-tools.md
@@ -107,7 +107,7 @@ No setup is complete without a good linter or formatter. Some editors offer thei
 
 ESLint is a JavaScript linting utility, designed to find problematic patterns or code that does not adhere to certain style guidelines, by utilizing static analysis patterns. Its popularity has spread like wildfire and is the de facto linting tool for many of the popular frameworks like Vue and React.
 
-[Vue.cli](../ecosystem/build-tools.md#vue-cli) offers a fully setup ESLint configuration, thanks to the incredible work by the people behind the [Vue ESLint](https://eslint.vuejs.org/) project. It is constantly being improved and worked on, offering a large set of rules, from basic Vue style guidelines, to very strict ones, keeping code as close to the [Official Vue Style Guide](https://vuejs.org/v2/style-guide/) as possible. It also allows you to pick between Standard or Airbnb code style rules.
+[Vue CLI](../ecosystem/build-tools.md#vue-cli) offers a fully setup ESLint configuration, thanks to the incredible work by the people behind the [Vue ESLint](https://eslint.vuejs.org/) project. It is constantly being improved and worked on, offering a large set of rules, from basic Vue style guidelines, to very strict ones, keeping code as close to the [Official Vue Style Guide](https://vuejs.org/v2/style-guide/) as possible. It also allows you to pick between Standard or Airbnb code style rules.
 
 #### How to install Vue ESLint plugin
 
@@ -158,13 +158,13 @@ Every major editor comes with ESLint support, either by an official or a communi
 
 Prettier is a code formatting tool that enforces a very opinionated coding style onto many languages, among which are JavaScript, CSS and HTML. Its main benefits are that it integrates into any of the popular editors and can format code on each save of the IDE, keeping code styles the as close as possible between multiple developers.
 
-The lack of options are actually one of its strong points. enforcing sensible defaults across the board.
+The lack of options are actually one of its strong points, enforcing sensible defaults across the board.
 
 #### How to use Prettier with Vue
 
-If you just want to use prettier, you can do so by installing it and using it directly via the command line. Follow the [installation guide](https://prettier.io/docs/en/install.html) for more details.
+If you just want to use Prettier, you can do so by installing it and using it directly via the command line. Follow the [installation guide](https://prettier.io/docs/en/install.html) for more details.
 
-#### Using prettier with ESLint
+#### Using Prettier with ESLint
 
 Prettier however does not work well with ESLint, out of the box. When used together, most often they have colliding rules between their style configurations. The problem is that, you cannot disable most of those in Prettier, as it was made to be "all or nothing" kind of thing.
 

--- a/docs/guide/ecosystem/forms.md
+++ b/docs/guide/ecosystem/forms.md
@@ -177,7 +177,7 @@ Out of all kinds of form fields, multiselect is usually the most tricky to imple
 </useful-links>
 
 
-## Form tutorials
+## Form Tutorials
 
 Here's a list of selected general tutorials on how to write forms in Vue.js that don't require using any specific library.
 

--- a/docs/guide/ecosystem/legacy.md
+++ b/docs/guide/ecosystem/legacy.md
@@ -1,4 +1,4 @@
-# Legacy packages
+# Legacy Packages
 
 Here we list popular Vue libraries that have had their time of fame and glory and are now either not actively
 developed or obsolete.

--- a/docs/guide/ecosystem/projects-worth-mentioning.md
+++ b/docs/guide/ecosystem/projects-worth-mentioning.md
@@ -1,4 +1,5 @@
-# Projects worth mentioning
-These are projects that we just dont have a category for, but are absolutely worth mentioning. 
+# Projects Worth Mentioning
+
+These are projects that we just don't have a category for, but are absolutely worth mentioning.
 
 ## VueStorefront

--- a/docs/guide/ecosystem/projects-worth-mentioning.md
+++ b/docs/guide/ecosystem/projects-worth-mentioning.md
@@ -1,5 +1,4 @@
 # Projects Worth Mentioning
-
-These are projects that we just don't have a category for, but are absolutely worth mentioning.
+These are projects that we just dont have a category for, but are absolutely worth mentioning. 
 
 ## VueStorefront

--- a/docs/guide/ecosystem/server-side-rendering.md
+++ b/docs/guide/ecosystem/server-side-rendering.md
@@ -7,10 +7,10 @@ The difference is, that the server renders the page only on first page visit, on
 <useful-links>
 <useful-links-section title="Tutorials">
 
-* [The Benefits of Server Side Rendering Over Client Side Rendering](https://medium.com/walmartlabs/the-benefits-of-server-side-rendering-over-client-side-rendering-5d07ff2cefe8) <badge>Good read</badge>
-* [What’s Server Side Rendering and do I need it?](https://medium.com/@baphemot/whats-server-side-rendering-and-do-i-need-it-cb42dc059b38)
-* [When to use Server-Side Rendering (SSR) in Vue.js projects](https://codeburst.io/when-to-use-server-side-rendering-ssr-in-vue-js-projects-697bd925d57b)
-* [What is React Server Side Rendering and should I use it?](https://dev.to/mladenstojanovic/what-is-react-server-side-rendering-and-should-i-use-it-5b7i) - For React, by the concepts are the same.
+- [The Benefits of Server Side Rendering Over Client Side Rendering](https://medium.com/walmartlabs/the-benefits-of-server-side-rendering-over-client-side-rendering-5d07ff2cefe8) <badge>Good read</badge>
+- [What’s Server Side Rendering and do I need it?](https://medium.com/@baphemot/whats-server-side-rendering-and-do-i-need-it-cb42dc059b38)
+- [When to use Server-Side Rendering (SSR) in Vue.js projects](https://codeburst.io/when-to-use-server-side-rendering-ssr-in-vue-js-projects-697bd925d57b)
+- [What is React Server Side Rendering and should I use it?](https://dev.to/mladenstojanovic/what-is-react-server-side-rendering-and-should-i-use-it-5b7i) - For React, by the concepts are the same.
 
 </useful-links-section>
 </useful-links>
@@ -19,29 +19,29 @@ The difference is, that the server renders the page only on first page visit, on
 
 Server side rendering solves a few of the most annoying problems of single-page applications:
 
-### SEO friendly 
+### SEO friendly
 
-Most crawlers cannot scan websites that are rendered with JavaScript, resulting search engines registering empty pages without content. This directly leads to bad search engine ranking. 
+Most crawlers cannot scan websites that are rendered with JavaScript, resulting search engines registering empty pages without content. This directly leads to bad search engine ranking.
 
-**Note:** Google can actually parse and crawl JavaScript rendered websites, but this still does not guarantee good ranking. They also use an older version of Chrome to render the pages, which can lead to errors if code is not transpiled to support older browsers. 
+**Note:** Google can actually parse and crawl JavaScript rendered websites, but this still does not guarantee good ranking. They also use an older version of Chrome to render the pages, which can lead to errors if code is not transpiled to support older browsers.
 
 With SSR, pages are returned as fully rendered HTML by the server, allowing for crawlers to scan at will.
 
 ### Fast load on slower devices
 
-Heavy applications that require lots of resources for the initial rendering, may cause slower or older devices to struggle. This is a real problem, as the average user doesn't have the latest cutting edge mobile device. 
+Heavy applications that require lots of resources for the initial rendering, may cause slower or older devices to struggle. This is a real problem, as the average user doesn't have the latest cutting edge mobile device.
 
 With SSR, the page is fully rendered on the server, eliminating that initial burden for lower end devices. When paired with some other optimisation techniques, like code splitting, pages can load much faster.
 
 ### Social Presence
 
-When sharing your website on various social media, they will show a small preview and extract metadata from it. Normal SPA applications are very poor at this and often result in blank pages with little to no metadata. Social media crawlers cant really parse JavaScript, so they dont know what to do with SPAs.
+When sharing your website on various social media, they will show a small preview and extract metadata from it. Normal SPA applications are very poor at this and often result in blank pages with little to no metadata. Social media crawlers cant really parse JavaScript, so they don't know what to do with SPAs.
 
 With SSR, pages are displayed with nice previews, as both the page content it self and meta tag data is present, allowing for social media crawlers to extract what they need.
 
 ### Time To First Paint (TTFP)
 
-Pages will be rendered faster when using SSR, as the browser does not need to download the whole JavaScript bundle to start rendering. This does not however mean a fully functioning website. 
+Pages will be rendered faster when using SSR, as the browser does not need to download the whole JavaScript bundle to start rendering. This does not however mean a fully functioning website.
 
 <useful-links>
 <useful-links-section title="Internal Pages">
@@ -79,23 +79,23 @@ Because there is usually a live Node.js instance always on, waiting to render a 
 
 This is directly related to the above. Server load is higher on initial request, while pages are being rendered, sometimes blocking other operations until the process is done.
 
-### Platform specific APIs are not available
+### Platform Specific APIs are not Available
 
-Because the app is rendered in server environment, there are specific APIs that are not available, like the `window` object. This means libraries like sliders and carousels may not work, and will throw errors during render. 
+Because the app is rendered in server environment, there are specific APIs that are not available, like the `window` object. This means libraries like sliders and carousels may not work, and will throw errors during render.
 
 To overcome this, developers should not interact with those APIs, in places, that are being called during server rendering. Their usage should be moved to lifecycle hooks like `mounted`, where the browser environment is present.
- 
- With sliders and carousels, you could delay their rendering to after the client receives the page, so it gets rendered on the browser.
- 
+
+With sliders and carousels, you could delay their rendering to after the client receives the page, so it gets rendered on the browser.
+
 <useful-links>
 <useful-links-section title="Tutorials">
  
-* [The guide to write universal, SSR-ready Vue components](https://blog.lichter.io/posts/the-guide-to-write-universal-ssr-ready-vue-compon/#window%2C-document%2C-and-friends---platform-specific-apis)
+* [The guide to writing universal, SSR-ready Vue components](https://blog.lichter.io/posts/the-guide-to-write-universal-ssr-ready-vue-compon/#window%2C-document%2C-and-friends---platform-specific-apis)
 
 </useful-links-section>
 </useful-links>
 
-### Complex to transform deployed SPA to SSR
+### Complex to Transform Deployed SPA to SSR
 
 Because of the above, already deployed websites are harder to transform to SSR, as there might be a lot of plugins or UI components, that rely on the Platform Specific APIs, explained above.
 
@@ -103,7 +103,7 @@ This is an issue mostly related with library and plugin authors not providing SS
 
 There are ways around this, like using the `no-ssr` component helpers, which delay rendering of components to the browser. This means that the component tag will be returned in the initial html response and not its rendered template. This might be problematic for components with SEO heavy content.
 
-## Available options for Vue
+## Available Options for Vue
 
 :::tip
 This part of the page is still in development and could use some help.
@@ -120,6 +120,7 @@ If you are searching for a well tested solution, with a large community and nice
 Learn more about it on the dedicated [Nuxt](./nuxt.md) page.
 
 ## Servue
+
 [Servue](https://futureaus.github.io/servue/) shares a similar scope to Nuxtjs, it allows you to render `.vue` files into rendered html. It includes features for head meta tag management, layouts and more. Servue is more suitable for Multi-page-applications using existing server-side routing systems such as koa/koa-router or express.js
 
 ## Ream
@@ -130,22 +131,22 @@ If you need more freedom to configure your application, with little to no interf
 
 ## Vue Server Renderer
 
-Vue server renderer is a lower level tool that is used by most of the above mentioned frameworks to render Vue apps on the server.
+Vue Server Renderer is a lower level tool that is used by most of the above mentioned frameworks to render Vue apps on the server.
 
 You can use it in tandem with an Express server or similar solution, to render pages on each user visit to the app. Just keep in mind, you will have to write a lot more boilerplate and configuration by yourself, compared to the already pre-made solutions.
 
-If you dont need some really custom solution, we would advise you to pick one of the pre-made tools mentioned above.
+If you don't need some really custom solution, we would advise you to pick one of the pre-made tools mentioned above.
 
 <useful-links>
 <useful-links-section title="Official">
 
-* [SSR Docs](https://ssr.vuejs.org/)
+- [SSR Docs](https://ssr.vuejs.org/)
 
 </useful-links-section>
 <useful-links-section title="Tutorials">
 
-* [Basic Server Side Rendering with Vue.js and Express](https://alligator.io/vuejs/basic-ssr/)
-* [VueJs: Server Side Render with Vue-router](https://medium.com/frontend-fun/vuejs-server-side-render-with-vue-router-e73d51699873)
+- [Basic Server Side Rendering with Vue.js and Express](https://alligator.io/vuejs/basic-ssr/)
+- [VueJs: Server Side Render with Vue-router](https://medium.com/frontend-fun/vuejs-server-side-render-with-vue-router-e73d51699873)
 
 </useful-links-section>
 </useful-links>

--- a/docs/guide/ecosystem/server-side-rendering.md
+++ b/docs/guide/ecosystem/server-side-rendering.md
@@ -7,10 +7,10 @@ The difference is, that the server renders the page only on first page visit, on
 <useful-links>
 <useful-links-section title="Tutorials">
 
-- [The Benefits of Server Side Rendering Over Client Side Rendering](https://medium.com/walmartlabs/the-benefits-of-server-side-rendering-over-client-side-rendering-5d07ff2cefe8) <badge>Good read</badge>
-- [What’s Server Side Rendering and do I need it?](https://medium.com/@baphemot/whats-server-side-rendering-and-do-i-need-it-cb42dc059b38)
-- [When to use Server-Side Rendering (SSR) in Vue.js projects](https://codeburst.io/when-to-use-server-side-rendering-ssr-in-vue-js-projects-697bd925d57b)
-- [What is React Server Side Rendering and should I use it?](https://dev.to/mladenstojanovic/what-is-react-server-side-rendering-and-should-i-use-it-5b7i) - For React, by the concepts are the same.
+* [The Benefits of Server Side Rendering Over Client Side Rendering](https://medium.com/walmartlabs/the-benefits-of-server-side-rendering-over-client-side-rendering-5d07ff2cefe8) <badge>Good read</badge>
+* [What’s Server Side Rendering and do I need it?](https://medium.com/@baphemot/whats-server-side-rendering-and-do-i-need-it-cb42dc059b38)
+* [When to use Server-Side Rendering (SSR) in Vue.js projects](https://codeburst.io/when-to-use-server-side-rendering-ssr-in-vue-js-projects-697bd925d57b)
+* [What is React Server Side Rendering and should I use it?](https://dev.to/mladenstojanovic/what-is-react-server-side-rendering-and-should-i-use-it-5b7i) - For React, by the concepts are the same.
 
 </useful-links-section>
 </useful-links>
@@ -19,17 +19,17 @@ The difference is, that the server renders the page only on first page visit, on
 
 Server side rendering solves a few of the most annoying problems of single-page applications:
 
-### SEO friendly
+### SEO friendly 
 
-Most crawlers cannot scan websites that are rendered with JavaScript, resulting search engines registering empty pages without content. This directly leads to bad search engine ranking.
+Most crawlers cannot scan websites that are rendered with JavaScript, resulting search engines registering empty pages without content. This directly leads to bad search engine ranking. 
 
-**Note:** Google can actually parse and crawl JavaScript rendered websites, but this still does not guarantee good ranking. They also use an older version of Chrome to render the pages, which can lead to errors if code is not transpiled to support older browsers.
+**Note:** Google can actually parse and crawl JavaScript rendered websites, but this still does not guarantee good ranking. They also use an older version of Chrome to render the pages, which can lead to errors if code is not transpiled to support older browsers. 
 
 With SSR, pages are returned as fully rendered HTML by the server, allowing for crawlers to scan at will.
 
-### Fast load on slower devices
+### Fast Load on Slower Devices
 
-Heavy applications that require lots of resources for the initial rendering, may cause slower or older devices to struggle. This is a real problem, as the average user doesn't have the latest cutting edge mobile device.
+Heavy applications that require lots of resources for the initial rendering, may cause slower or older devices to struggle. This is a real problem, as the average user doesn't have the latest cutting edge mobile device. 
 
 With SSR, the page is fully rendered on the server, eliminating that initial burden for lower end devices. When paired with some other optimisation techniques, like code splitting, pages can load much faster.
 
@@ -41,7 +41,7 @@ With SSR, pages are displayed with nice previews, as both the page content it se
 
 ### Time To First Paint (TTFP)
 
-Pages will be rendered faster when using SSR, as the browser does not need to download the whole JavaScript bundle to start rendering. This does not however mean a fully functioning website.
+Pages will be rendered faster when using SSR, as the browser does not need to download the whole JavaScript bundle to start rendering. This does not however mean a fully functioning website. 
 
 <useful-links>
 <useful-links-section title="Internal Pages">
@@ -55,15 +55,15 @@ Pages will be rendered faster when using SSR, as the browser does not need to do
 
 SSR sounds awesome, there are however some things that need to be taken in consideration.
 
-### Time to interaction
+### Time to Interactive
 
 Even though users can see the website, it doesn't meant it is fully working. For very dynamic websites, with a lot of JavaScript logic driving the UI, this can lead to weird situations where the page is rendered, looks ready, but the app bundle is still downloading, so no JavaScript logic can be executed yet.
 
-### Time to first byte (TTFB) is slower
+### Time to First Byte (TTFB) is Slower
 
 Because the server has to actually do the rendering, fetch async data and so on, the time it takes for the response to hit the browser is bigger.
 
-### Server costs
+### Server Costs
 
 Because there is usually a live Node.js instance always on, waiting to render a request, server costs are higher than static file hosting.
 
@@ -81,16 +81,16 @@ This is directly related to the above. Server load is higher on initial request,
 
 ### Platform Specific APIs are not Available
 
-Because the app is rendered in server environment, there are specific APIs that are not available, like the `window` object. This means libraries like sliders and carousels may not work, and will throw errors during render.
+Because the app is rendered in server environment, there are specific APIs that are not available, like the `window` object. This means libraries like sliders and carousels may not work, and will throw errors during render. 
 
 To overcome this, developers should not interact with those APIs, in places, that are being called during server rendering. Their usage should be moved to lifecycle hooks like `mounted`, where the browser environment is present.
-
-With sliders and carousels, you could delay their rendering to after the client receives the page, so it gets rendered on the browser.
-
+ 
+ With sliders and carousels, you could delay their rendering to after the client receives the page, so it gets rendered on the browser.
+ 
 <useful-links>
 <useful-links-section title="Tutorials">
  
-* [The guide to writing universal, SSR-ready Vue components](https://blog.lichter.io/posts/the-guide-to-write-universal-ssr-ready-vue-compon/#window%2C-document%2C-and-friends---platform-specific-apis)
+* [The guide to write universal, SSR-ready Vue components](https://blog.lichter.io/posts/the-guide-to-write-universal-ssr-ready-vue-compon/#window%2C-document%2C-and-friends---platform-specific-apis)
 
 </useful-links-section>
 </useful-links>
@@ -120,7 +120,6 @@ If you are searching for a well tested solution, with a large community and nice
 Learn more about it on the dedicated [Nuxt](./nuxt.md) page.
 
 ## Servue
-
 [Servue](https://futureaus.github.io/servue/) shares a similar scope to Nuxtjs, it allows you to render `.vue` files into rendered html. It includes features for head meta tag management, layouts and more. Servue is more suitable for Multi-page-applications using existing server-side routing systems such as koa/koa-router or express.js
 
 ## Ream
@@ -140,13 +139,13 @@ If you don't need some really custom solution, we would advise you to pick one o
 <useful-links>
 <useful-links-section title="Official">
 
-- [SSR Docs](https://ssr.vuejs.org/)
+* [SSR Docs](https://ssr.vuejs.org/)
 
 </useful-links-section>
 <useful-links-section title="Tutorials">
 
-- [Basic Server Side Rendering with Vue.js and Express](https://alligator.io/vuejs/basic-ssr/)
-- [VueJs: Server Side Render with Vue-router](https://medium.com/frontend-fun/vuejs-server-side-render-with-vue-router-e73d51699873)
+* [Basic Server Side Rendering with Vue.js and Express](https://alligator.io/vuejs/basic-ssr/)
+* [VueJs: Server Side Render with Vue-router](https://medium.com/frontend-fun/vuejs-server-side-render-with-vue-router-e73d51699873)
 
 </useful-links-section>
 </useful-links>

--- a/docs/guide/ecosystem/ui-libraries.md
+++ b/docs/guide/ecosystem/ui-libraries.md
@@ -24,19 +24,19 @@ If you don't have time to read all of this and just need a quick answer:
 </useful-links-section>
 <useful-links-section title="Desktop mainly">
 
-- [Element UI](#element-ui) - extensive, desktop oriented, widely popular in asia
-- [iView](#iview)
+ - [Element UI](#element-ui) - extensive, desktop oriented, widely popular in asia
+ - [iView](#iview)
 
 </useful-links-section>
 <useful-links-section title="Easy get into">
 
-- [Bootstrap-Vue](#bootstrap-vue) - Bootstrap based
-- [Buefy](#buefy) - Bulma based
+* [Bootstrap-Vue](#bootstrap-vue) - Bootstrap based
+* [Buefy](#buefy) - Bulma based
 
 </useful-links-section>
 <useful-links-section title="Most flexible">
 
-- [Tailwind](#tailwind-css)
+* [Tailwind](#tailwind-css)
 
 </useful-links-section>
 </useful-links>
@@ -46,7 +46,6 @@ If you don't have time to read all of this and just need a quick answer:
 This section is supposed to contain the guidelines on how to decide which UI library to use.
 
 Here are some topics that should be covered:
-
 - do you really need an UI library?
 - how do you plan to approach mobile version of your website or application
 - are you fine with a library that doesn't provide comprehensive support and large community
@@ -56,14 +55,14 @@ Here are some topics that should be covered:
 
 ## Material Design
 
-Material Design is a very popular design concept not only in Vue.js world. Combining flat visual style with shadows and other lightning effects, it was primarily created with Android mobile applications in mind, but is widely used on traditional websites too.
+Material Design is a very popular design concept not only in Vue.js world. Combining flat visual style with shadows and other lightning effects, it was primarily created with Android mobile applications in mind, but is widely used on traditional websites too. 
 
 The components in libraries such as [Vuetify](#vuetify) or [Vue-Material](#vue-material) look good by default, but since they were written with a certain design style in mind, they're not fully customizable. However, the new Material Design 2 specification brought more focus on flexible theming and we can expect the libraries to follow this move in 2019.
 
 <useful-links>
 <useful-links-section title="Official">
 
-- [Material Design documentation](https://material.io/)
+* [Material Design documentation](https://material.io/)
 
 </useful-links-section>
 </useful-links>
@@ -78,12 +77,13 @@ The library's ecosystem provides multiple tools, such as theme generator, Webpac
 
 Internally, Vuetify is written with Typescript. The upcoming release of Vuetify 2 with improved theme system, accessibility and performance, will also bring the move from Stylus to SASS.
 
+
 <useful-links>
 <useful-links-section title="Official">
 
-- [Vuetify repository](https://github.com/vuetifyjs/vuetify)
-- [Vuetify documentation](https://vuetifyjs.com/en/)
-- [Vuetify chat on Discord](https://community.vuetifyjs.com/)
+* [Vuetify repository](https://github.com/vuetifyjs/vuetify) 
+* [Vuetify documentation](https://vuetifyjs.com/en/) 
+* [Vuetify chat on Discord](https://community.vuetifyjs.com/)
 
 </useful-links-section>
 </useful-links>
@@ -94,19 +94,21 @@ Internally, Vuetify is written with Typescript. The upcoming release of Vuetify 
 
 The difference in popularity is big, but if you're looking for a library that follows Material Design principles to the letter, give it a try.
 
+
 <useful-links>
 <useful-links-section title="Official">
 
-- [Vue Material repository](https://github.com/vuematerial/vue-material)
-- [Vue Material documentation](https://vuematerial.io/)
-- [Vue Material chat on Discord](https://discord.gg/vuematerial)
+* [Vue Material repository](https://github.com/vuematerial/vue-material)
+* [Vue Material documentation](https://vuematerial.io/)
+* [Vue Material chat on Discord](https://discord.gg/vuematerial)
 
 </useful-links-section>
 </useful-links>
 
+
 ## Ant Design
 
-Ant Design is kind of the opposite of previously mentioned Material Design. The libraries following this specification are meant to be used primarily on desktop, so their responsive design support is scarce.
+Ant Design is kind of the opposite of previously mentioned Material Design. The libraries following this specification are meant to be used primarily on desktop, so their responsive design support is scarce. 
 
 The reason? Just like Material Design was created by Google, AntD is brought by designers from Alibaba - the largest e-commerce company in China. It's specifically targeted towards the Chinese web market, where traditional websites aren't usually accessed on mobile devices. Such libraries often provide separate solutions for mobile applications, based on a separate And Design Mobile specification.
 
@@ -117,8 +119,8 @@ Other than standard websites, Ant Design is a good choice for developers writing
 <useful-links>
 <useful-links-section title="Official">
 
-- [Ant Design documentation](https://ant.design/)
-- [Ant Design Vue](https://vuecomponent.github.io/ant-design-vue/docs/vue/introduce/)
+* [Ant Design documentation](https://ant.design/)
+* [Ant Design Vue](https://vuecomponent.github.io/ant-design-vue/docs/vue/introduce/)
 
 </useful-links-section>
 </useful-links>
@@ -131,15 +133,17 @@ Element UI provides starter kits for both general usage and Laravel projects, as
 
 The library's success resulted in porting Element UI to Angular and React ecosystems.
 
+
 <useful-links>
 <useful-links-section title="Official">
 
-- [Element UI repository](https://github.com/ElemeFE/element)
-- [Element UI documentation](https://element.eleme.io/)
-- [Element UI chat on Gitter](https://gitter.im/element-en/Lobby)
+* [Element UI repository](https://github.com/ElemeFE/element) 
+* [Element UI documentation](https://element.eleme.io/) 
+* [Element UI chat on Gitter](https://gitter.im/element-en/Lobby)
 
 </useful-links-section>
 </useful-links>
+
 
 ### iView
 
@@ -148,8 +152,8 @@ While not as well-known as Element UI, Iview is a valid, well maintained alterna
 <useful-links>
 <useful-links-section title="Official">
 
-- [Iview repository](https://github.com/iview/iview)
-- [Iview documentation](https://iviewui.com)
+* [Iview repository](https://github.com/iview/iview)
+* [Iview documentation](https://iviewui.com)
 
 </useful-links-section>
 </useful-links>
@@ -162,49 +166,50 @@ Remember that you will still have to reach out to original framework's documenta
 
 ### Bootstrap-Vue <badge text="Backender's Choice"/>
 
-> Bootstrap-Vue provides one of the most comprehensive implementations of Bootstrap V4.3 components and grid system available for Vue.js 2.6+, complete with extensive and automated WAI-ARIA accessibility markup.
+> Bootstrap-Vue provides one of the most comprehensive implementations of Bootstrap V4.3 components and grid system available for Vue.js 2.6+, complete with extensive and automated WAI-ARIA accessibility markup. 
 
 If you want to use Bootstrap 4 for your project, Bootstrap-Vue is the community's most often recommendation. It's a set of components natively written with Vue.js, so you don't have to worry about mixing Vue with JQuery. It's easy to use it with both Vue CLI and Nuxt.
 
 <useful-links>
 <useful-links-section title="Official">
 
-- [Bootstrap-Vue repository](https://github.com/bootstrap-vue/bootstrap-vue)
-- [Bootstrap-Vue documentation](https://bootstrap-vue.js.org/)
-- [Bootstrap-Vue chat on Discord](https://discordapp.com/invite/j2Mtcny)
+* [Bootstrap-Vue repository](https://github.com/bootstrap-vue/bootstrap-vue) 
+* [Bootstrap-Vue documentation](https://bootstrap-vue.js.org/) 
+* [Bootstrap-Vue chat on Discord](https://discordapp.com/invite/j2Mtcny)
 
 </useful-links-section>
 </useful-links>
 
 ### Buefy
 
-Bulma grew up to be one of top CSS frameworks, but unlike most of them, it doesn't offer any Javascript functionality. That's where Buefy comes into play. It provides both a set of components and an easy way to integrate Bulma into your project.
+Bulma grew up to be one of top CSS frameworks, but unlike most of them, it doesn't offer any Javascript functionality. That's where Buefy comes into play. It provides both a set of components and an easy way to integrate Bulma into your project. 
 
 Buefy's versions are synchronized with Bulma, so you can be sure that same versions of both frameworks are fully compatible with each other.
 
 <useful-links>
 <useful-links-section title="Official">
 
-- [Buefy repository](https://github.com/buefy/buefy)
-- [Buefy documentation](https://buefy.github.io)
-- [Buefy chat on Discord](https://discordapp.com/invite/ZkdFJMr)
+* [Buefy repository](https://github.com/buefy/buefy)
+* [Buefy documentation](https://buefy.github.io)
+* [Buefy chat on Discord](https://discordapp.com/invite/ZkdFJMr)
 
 </useful-links-section>
 </useful-links>
 
 ### Vuikit
 
-Vuikit is a Vue integration library that provides wrappers for [Uikit](https://getuikit.com/) framework. While not as well-known in Vue.js ecosystem as Bootstrap or Bulma, Uikit is a robust library that covers a wide variety of CSS & JS components, with some unique features that you won't find elsewhere out of the box.
+Vuikit is a Vue integration library that provides wrappers for [Uikit](https://getuikit.com/) framework. While not as well-known in Vue.js ecosystem as Bootstrap or Bulma, Uikit is a robust library that covers a wide variety of CSS & JS components, with some unique features that you won't find elsewhere out of the box. 
 
 <useful-links>
 <useful-links-section title="Official">
 
-- [Vuikit repository](https://github.com/vuikit/vuikit)
-- [Vuikit documentation](https://vuikit.js.org/)
-- [UIkit chat on Gitter](https://gitter.im/uikit/uikit)
+* [Vuikit repository](https://github.com/vuikit/vuikit) 
+* [Vuikit documentation](https://vuikit.js.org/) 
+* [UIkit chat on Gitter](https://gitter.im/uikit/uikit)
 
 </useful-links-section>
 </useful-links>
+
 
 ### Semantic-UI-Vue
 
@@ -213,9 +218,9 @@ Despite its popularity, [Semantic UI](https://semantic-ui.com/) never really hit
 <useful-links>
 <useful-links-section title="Official">
 
-- [Semantic-UI-Vue repository](https://github.com/Semantic-UI-Vue/Semantic-UI-Vue)
-- [Semantic-UI-Vue documentation](https://semantic-ui-vue.github.io)
-- [Semantic-UI-Vue chat on Gitter](https://gitter.im/Semantic-UI-Vue)
+* [Semantic-UI-Vue repository](https://github.com/Semantic-UI-Vue/Semantic-UI-Vue)
+* [Semantic-UI-Vue documentation](https://semantic-ui-vue.github.io) 
+* [Semantic-UI-Vue chat on Gitter](https://gitter.im/Semantic-UI-Vue)
 
 </useful-links-section>
 </useful-links>
@@ -224,36 +229,36 @@ Despite its popularity, [Semantic UI](https://semantic-ui.com/) never really hit
 
 ### Tailwind CSS <badge text="Most Flexible"/>
 
-> A utility-first CSS framework for rapidly building custom user interfaces.
+> A utility-first CSS framework for rapidly building custom user interfaces. 
 
 Tailwind is very well accepted in the Vue community as it integrates very nicely with the concept of components. Integration is as simple as installing Tailwind and creating a config and importing it in your app.
 
 <useful-links>
 <useful-links-section title="Official">
 
-- [Tailwind Docs](https://tailwindcss.com/docs/what-is-tailwind/)
+* [Tailwind Docs](https://tailwindcss.com/docs/what-is-tailwind/)
 
 </useful-links-section>
 <useful-links-section title="Tutorials">
 
-- [Using Tailwind with Vue.js](https://flaviocopes.com/vue-tailwind/)
-- [How to use Tailwind CSS in Vue together with CSS Modules](https://stefanzweifel.io/posts/how-to-use-tailwind-css-in-vue-together-with-css-modules)
+* [Using Tailwind with Vue.js](https://flaviocopes.com/vue-tailwind/)
+* [How to use Tailwind CSS in Vue together with CSS Modules](https://stefanzweifel.io/posts/how-to-use-tailwind-css-in-vue-together-with-css-modules)
 
 </useful-links-section>
 </useful-links>
 
 ### VueSax <badge type="warning" text="In Development"/>
 
-From all the rest of available libraries, VueSax seems to be the most promising one in terms of both features and maintainment. The goal is to create an UI library that is fully independent in terms of colors, shapes and design choices, focusing on core JS functionality.
+From all the rest of available libraries, VueSax seems to be the most promising one in terms of both features and maintainment. The goal is to create an UI library that is fully independent in terms of colors, shapes and design choices, focusing on core JS functionality. 
 
 The author doesn't recommend to use it in production yet, but for small non-commercial projects it may be worth trying out.
 
 <useful-links>
 <useful-links-section title="Official">
 
-- [VueSax repository](https://github.com/lusaxweb/vuesax)
-- [VueSax documentation](https://lusaxweb.github.io/vuesax/)
-- [VueSax chat on Discord](https://discord.gg/9dsKtvB)
+* [VueSax repository](https://github.com/lusaxweb/vuesax) 
+* [VueSax documentation](https://lusaxweb.github.io/vuesax/) 
+* [VueSax chat on Discord](https://discord.gg/9dsKtvB)
 
 </useful-links-section>
 </useful-links>

--- a/docs/guide/ecosystem/ui-libraries.md
+++ b/docs/guide/ecosystem/ui-libraries.md
@@ -14,7 +14,7 @@ Most of the libraries covered in this chapter are based on either Material Desig
 
 ## Summary (TLDR)
 
-If you dont have time to read all of this and just need a quick answer:
+If you don't have time to read all of this and just need a quick answer:
 
 <useful-links>
 <useful-links-section title="Users choice">
@@ -24,19 +24,19 @@ If you dont have time to read all of this and just need a quick answer:
 </useful-links-section>
 <useful-links-section title="Desktop mainly">
 
- - [Element UI](#element-ui) - extensive, desktop oriented, widely popular in asia
- - [iView](#iview)
+- [Element UI](#element-ui) - extensive, desktop oriented, widely popular in asia
+- [iView](#iview)
 
 </useful-links-section>
 <useful-links-section title="Easy get into">
 
-* [Bootstrap-Vue](#bootstrap-vue) - Bootstrap based
-* [Buefy](#buefy) - Bulma based
+- [Bootstrap-Vue](#bootstrap-vue) - Bootstrap based
+- [Buefy](#buefy) - Bulma based
 
 </useful-links-section>
 <useful-links-section title="Most flexible">
 
-* [Tailwind](#tailwind-css)
+- [Tailwind](#tailwind-css)
 
 </useful-links-section>
 </useful-links>
@@ -46,6 +46,7 @@ If you dont have time to read all of this and just need a quick answer:
 This section is supposed to contain the guidelines on how to decide which UI library to use.
 
 Here are some topics that should be covered:
+
 - do you really need an UI library?
 - how do you plan to approach mobile version of your website or application
 - are you fine with a library that doesn't provide comprehensive support and large community
@@ -55,14 +56,14 @@ Here are some topics that should be covered:
 
 ## Material Design
 
-Material Design is a very popular design concept not only in Vue.js world. Combining flat visual style with shadows and other lightning effects, it was primarily created with Android mobile applications in mind, but is widely used on traditional websites too. 
+Material Design is a very popular design concept not only in Vue.js world. Combining flat visual style with shadows and other lightning effects, it was primarily created with Android mobile applications in mind, but is widely used on traditional websites too.
 
 The components in libraries such as [Vuetify](#vuetify) or [Vue-Material](#vue-material) look good by default, but since they were written with a certain design style in mind, they're not fully customizable. However, the new Material Design 2 specification brought more focus on flexible theming and we can expect the libraries to follow this move in 2019.
 
 <useful-links>
 <useful-links-section title="Official">
 
-* [Material Design documentation](https://material.io/)
+- [Material Design documentation](https://material.io/)
 
 </useful-links-section>
 </useful-links>
@@ -77,13 +78,12 @@ The library's ecosystem provides multiple tools, such as theme generator, Webpac
 
 Internally, Vuetify is written with Typescript. The upcoming release of Vuetify 2 with improved theme system, accessibility and performance, will also bring the move from Stylus to SASS.
 
-
 <useful-links>
 <useful-links-section title="Official">
 
-* [Vuetify repository](https://github.com/vuetifyjs/vuetify) 
-* [Vuetify documentation](https://vuetifyjs.com/en/) 
-* [Vuetify chat on Discord](https://community.vuetifyjs.com/)
+- [Vuetify repository](https://github.com/vuetifyjs/vuetify)
+- [Vuetify documentation](https://vuetifyjs.com/en/)
+- [Vuetify chat on Discord](https://community.vuetifyjs.com/)
 
 </useful-links-section>
 </useful-links>
@@ -94,21 +94,19 @@ Internally, Vuetify is written with Typescript. The upcoming release of Vuetify 
 
 The difference in popularity is big, but if you're looking for a library that follows Material Design principles to the letter, give it a try.
 
-
 <useful-links>
 <useful-links-section title="Official">
 
-* [Vue Material repository](https://github.com/vuematerial/vue-material)
-* [Vue Material documentation](https://vuematerial.io/)
-* [Vue Material chat on Discord](https://discord.gg/vuematerial)
+- [Vue Material repository](https://github.com/vuematerial/vue-material)
+- [Vue Material documentation](https://vuematerial.io/)
+- [Vue Material chat on Discord](https://discord.gg/vuematerial)
 
 </useful-links-section>
 </useful-links>
 
-
 ## Ant Design
 
-Ant Design is kind of the opposite of previously mentioned Material Design. The libraries following this specification are meant to be used primarily on desktop, so their responsive design support is scarce. 
+Ant Design is kind of the opposite of previously mentioned Material Design. The libraries following this specification are meant to be used primarily on desktop, so their responsive design support is scarce.
 
 The reason? Just like Material Design was created by Google, AntD is brought by designers from Alibaba - the largest e-commerce company in China. It's specifically targeted towards the Chinese web market, where traditional websites aren't usually accessed on mobile devices. Such libraries often provide separate solutions for mobile applications, based on a separate And Design Mobile specification.
 
@@ -119,8 +117,8 @@ Other than standard websites, Ant Design is a good choice for developers writing
 <useful-links>
 <useful-links-section title="Official">
 
-* [Ant Design documentation](https://ant.design/)
-* [Ant Design Vue](https://vuecomponent.github.io/ant-design-vue/docs/vue/introduce/)
+- [Ant Design documentation](https://ant.design/)
+- [Ant Design Vue](https://vuecomponent.github.io/ant-design-vue/docs/vue/introduce/)
 
 </useful-links-section>
 </useful-links>
@@ -133,17 +131,15 @@ Element UI provides starter kits for both general usage and Laravel projects, as
 
 The library's success resulted in porting Element UI to Angular and React ecosystems.
 
-
 <useful-links>
 <useful-links-section title="Official">
 
-* [Element UI repository](https://github.com/ElemeFE/element) 
-* [Element UI documentation](https://element.eleme.io/) 
-* [Element UI chat on Gitter](https://gitter.im/element-en/Lobby)
+- [Element UI repository](https://github.com/ElemeFE/element)
+- [Element UI documentation](https://element.eleme.io/)
+- [Element UI chat on Gitter](https://gitter.im/element-en/Lobby)
 
 </useful-links-section>
 </useful-links>
-
 
 ### iView
 
@@ -152,8 +148,8 @@ While not as well-known as Element UI, Iview is a valid, well maintained alterna
 <useful-links>
 <useful-links-section title="Official">
 
-* [Iview repository](https://github.com/iview/iview)
-* [Iview documentation](https://iviewui.com)
+- [Iview repository](https://github.com/iview/iview)
+- [Iview documentation](https://iviewui.com)
 
 </useful-links-section>
 </useful-links>
@@ -166,50 +162,49 @@ Remember that you will still have to reach out to original framework's documenta
 
 ### Bootstrap-Vue <badge text="Backender's Choice"/>
 
-> Bootstrap-Vue provides one of the most comprehensive implementations of Bootstrap V4.3 components and grid system available for Vue.js 2.6+, complete with extensive and automated WAI-ARIA accessibility markup. 
+> Bootstrap-Vue provides one of the most comprehensive implementations of Bootstrap V4.3 components and grid system available for Vue.js 2.6+, complete with extensive and automated WAI-ARIA accessibility markup.
 
 If you want to use Bootstrap 4 for your project, Bootstrap-Vue is the community's most often recommendation. It's a set of components natively written with Vue.js, so you don't have to worry about mixing Vue with JQuery. It's easy to use it with both Vue CLI and Nuxt.
 
 <useful-links>
 <useful-links-section title="Official">
 
-* [Bootstrap-Vue repository](https://github.com/bootstrap-vue/bootstrap-vue) 
-* [Bootstrap-Vue documentation](https://bootstrap-vue.js.org/) 
-* [Bootstrap-Vue chat on Discord](https://discordapp.com/invite/j2Mtcny)
+- [Bootstrap-Vue repository](https://github.com/bootstrap-vue/bootstrap-vue)
+- [Bootstrap-Vue documentation](https://bootstrap-vue.js.org/)
+- [Bootstrap-Vue chat on Discord](https://discordapp.com/invite/j2Mtcny)
 
 </useful-links-section>
 </useful-links>
 
 ### Buefy
 
-Bulma grew up to be one of top CSS frameworks, but unlike most of them, it doesn't offer any Javascript functionality. That's where Buefy comes into play. It provides both a set of components and an easy way to integrate Bulma into your project. 
+Bulma grew up to be one of top CSS frameworks, but unlike most of them, it doesn't offer any Javascript functionality. That's where Buefy comes into play. It provides both a set of components and an easy way to integrate Bulma into your project.
 
 Buefy's versions are synchronized with Bulma, so you can be sure that same versions of both frameworks are fully compatible with each other.
 
 <useful-links>
 <useful-links-section title="Official">
 
-* [Buefy repository](https://github.com/buefy/buefy)
-* [Buefy documentation](https://buefy.github.io)
-* [Buefy chat on Discord](https://discordapp.com/invite/ZkdFJMr)
+- [Buefy repository](https://github.com/buefy/buefy)
+- [Buefy documentation](https://buefy.github.io)
+- [Buefy chat on Discord](https://discordapp.com/invite/ZkdFJMr)
 
 </useful-links-section>
 </useful-links>
 
 ### Vuikit
 
-Vuikit is a Vue integration library that provides wrappers for [Uikit](https://getuikit.com/) framework. While not as well-known in Vue.js ecosystem as Bootstrap or Bulma, Uikit is a robust library that covers a wide variety of CSS & JS components, with some unique features that you won't find elsewhere out of the box. 
+Vuikit is a Vue integration library that provides wrappers for [Uikit](https://getuikit.com/) framework. While not as well-known in Vue.js ecosystem as Bootstrap or Bulma, Uikit is a robust library that covers a wide variety of CSS & JS components, with some unique features that you won't find elsewhere out of the box.
 
 <useful-links>
 <useful-links-section title="Official">
 
-* [Vuikit repository](https://github.com/vuikit/vuikit) 
-* [Vuikit documentation](https://vuikit.js.org/) 
-* [UIkit chat on Gitter](https://gitter.im/uikit/uikit)
+- [Vuikit repository](https://github.com/vuikit/vuikit)
+- [Vuikit documentation](https://vuikit.js.org/)
+- [UIkit chat on Gitter](https://gitter.im/uikit/uikit)
 
 </useful-links-section>
 </useful-links>
-
 
 ### Semantic-UI-Vue
 
@@ -218,9 +213,9 @@ Despite its popularity, [Semantic UI](https://semantic-ui.com/) never really hit
 <useful-links>
 <useful-links-section title="Official">
 
-* [Semantic-UI-Vue repository](https://github.com/Semantic-UI-Vue/Semantic-UI-Vue)
-* [Semantic-UI-Vue documentation](https://semantic-ui-vue.github.io) 
-* [Semantic-UI-Vue chat on Gitter](https://gitter.im/Semantic-UI-Vue)
+- [Semantic-UI-Vue repository](https://github.com/Semantic-UI-Vue/Semantic-UI-Vue)
+- [Semantic-UI-Vue documentation](https://semantic-ui-vue.github.io)
+- [Semantic-UI-Vue chat on Gitter](https://gitter.im/Semantic-UI-Vue)
 
 </useful-links-section>
 </useful-links>
@@ -229,36 +224,36 @@ Despite its popularity, [Semantic UI](https://semantic-ui.com/) never really hit
 
 ### Tailwind CSS <badge text="Most Flexible"/>
 
-> A utility-first CSS framework for rapidly building custom user interfaces. 
+> A utility-first CSS framework for rapidly building custom user interfaces.
 
 Tailwind is very well accepted in the Vue community as it integrates very nicely with the concept of components. Integration is as simple as installing Tailwind and creating a config and importing it in your app.
 
 <useful-links>
 <useful-links-section title="Official">
 
-* [Tailwind Docs](https://tailwindcss.com/docs/what-is-tailwind/)
+- [Tailwind Docs](https://tailwindcss.com/docs/what-is-tailwind/)
 
 </useful-links-section>
 <useful-links-section title="Tutorials">
 
-* [Using Tailwind with Vue.js](https://flaviocopes.com/vue-tailwind/)
-* [How to use Tailwind CSS in Vue together with CSS Modules](https://stefanzweifel.io/posts/how-to-use-tailwind-css-in-vue-together-with-css-modules)
+- [Using Tailwind with Vue.js](https://flaviocopes.com/vue-tailwind/)
+- [How to use Tailwind CSS in Vue together with CSS Modules](https://stefanzweifel.io/posts/how-to-use-tailwind-css-in-vue-together-with-css-modules)
 
 </useful-links-section>
 </useful-links>
 
 ### VueSax <badge type="warning" text="In Development"/>
 
-From all the rest of available libraries, VueSax seems to be the most promising one in terms of both features and maintainment. The goal is to create an UI library that is fully independent in terms of colors, shapes and design choices, focusing on core JS functionality. 
+From all the rest of available libraries, VueSax seems to be the most promising one in terms of both features and maintainment. The goal is to create an UI library that is fully independent in terms of colors, shapes and design choices, focusing on core JS functionality.
 
 The author doesn't recommend to use it in production yet, but for small non-commercial projects it may be worth trying out.
 
 <useful-links>
 <useful-links-section title="Official">
 
-* [VueSax repository](https://github.com/lusaxweb/vuesax) 
-* [VueSax documentation](https://lusaxweb.github.io/vuesax/) 
-* [VueSax chat on Discord](https://discord.gg/9dsKtvB)
+- [VueSax repository](https://github.com/lusaxweb/vuesax)
+- [VueSax documentation](https://lusaxweb.github.io/vuesax/)
+- [VueSax chat on Discord](https://discord.gg/9dsKtvB)
 
 </useful-links-section>
 </useful-links>

--- a/docs/guide/learning/faq.md
+++ b/docs/guide/learning/faq.md
@@ -5,7 +5,7 @@ Below is a collection of the most commonly asked questions that new Vue develope
 Answers may contain links to other Vue community pages, external articles and blog posts, or even links to specialized docs, where said feature is explained in detail.
 
 ::: warning
-This page is still in early development. If you feel you can contribute, please dont hesitate to open a PR.
+This page is still in early development. If you feel you can contribute, please don't hesitate to open a PR.
 :::
 
 ## General Vue related
@@ -50,7 +50,7 @@ It is recommended that you know and use ES201x, as it certainly can diminish som
 
 ### How do I pass data to a component from server inside template
 
-You can use props and pass strings, numbers or json directly into the component's element tag. If you are passing numbers or json, dont forget to use `v-bind` or `:` shorthand syntax.
+You can use props and pass strings, numbers or json directly into the component's element tag. If you are passing numbers or json, don't forget to use `v-bind` or `:` shorthand syntax.
 
 <useful-links>
 <useful-links-section title="Tutorials">
@@ -249,7 +249,7 @@ They are most often used to create components, that would be rendered hundreds o
 
 ### How do I use computed properties inside functional component?
 
-Short answer, you dont. 
+Short answer, you don't. 
 
 Functional components generally use render functions or JSX, thus one could import or define simple functions on top of the `render` method, using them inside as data transformers, similar to computed properties. Even though not exactly computed properties, it can help you reduce template logic quite a lot. 
 
@@ -353,7 +353,7 @@ To pass a parameter to a getter, return a function from within the getter. The f
 </useful-links-section>
 <useful-links-section title="Tutorials">
 
-* [Vuex getters are great, but don’t overuse them](https://codeburst.io/vuex-getters-are-great-but-dont-overuse-them-9c946689b414)
+* [Vuex getters are great, but don’t overuse them](https://codeburst.io/vuex-getters-are-great-but-don't-overuse-them-9c946689b414)
 
 </useful-links-section>
 </useful-links>

--- a/docs/guide/learning/faq.md
+++ b/docs/guide/learning/faq.md
@@ -353,7 +353,7 @@ To pass a parameter to a getter, return a function from within the getter. The f
 </useful-links-section>
 <useful-links-section title="Tutorials">
 
-* [Vuex getters are great, but don’t overuse them](https://codeburst.io/vuex-getters-are-great-but-don't-overuse-them-9c946689b414)
+* [Vuex getters are great, but don’t overuse them](https://codeburst.io/vuex-getters-are-great-but-dont-overuse-them-9c946689b414)
 
 </useful-links-section>
 </useful-links>

--- a/docs/guide/learning/how-to-learn-vue.md
+++ b/docs/guide/learning/how-to-learn-vue.md
@@ -1,4 +1,4 @@
-# How to learn Vue
+# How to Learn Vue
 
 As with any technology, its best to start with the official documentation, in this case the [Vue.js Guide](https://vuejs.org/v2/guide/). The guide is a magnificent, constantly updated learning resource, which does a superb job at giving a good starting point, needed to build an application with Vue. From basic reactivity concepts and caveats, to more advanced use cases, it should be the first place to learn from.
 
@@ -27,13 +27,13 @@ If you want to find out how other people learn, the [Tips from Mentors](./tips-f
 </useful-links-section>
 </useful-links>
 
-## Categorizing applications by technology
+## Categorizing Applications by Technology
 
 When beginning to develop with Vue.js, it helps to know what kind of application you will be building. This will help you outline the kind of technologies you will need to master in order to start developing with Vue.
 
 In this section, we will go over the categories under which most websites fall under and the tech a developer needs to know to develop them with Vue. 
 
-## Vue enhanced websites
+## Vue Enhanced Websites
 
 Vue enhanced websites are traditional websites, rendered by a server side language, be it PHP, Node or other. 
 
@@ -41,7 +41,7 @@ Vue components can be used to enhance certain parts of the website, but they are
 
 Such websites can be split into:
 
-### Vue enhanced websites without a bundler
+### Vue Enhanced Websites Without a Bundler
  
 Vue can be added with a simple CDN link, components are built in plain JavaScript, with templates added to the HTML markup. 
  
@@ -70,7 +70,7 @@ This approach works for smaller websites or those that will not implement comple
 </useful-links-section>
 </useful-links>
 
-### Vue enhanced websites using a bundler
+### Vue Enhanced Websites Using a Bundler
 
  As the approach above, routing and page rendering is handled on the server, while Vue components are built using `.vue` single file components (SFC), keeping the codebase in an easier to manage state. This approach also allows for splitting up different parts of the application into small reusable modules.
  
@@ -130,7 +130,7 @@ If the project allows, it is strongly recommended to use the Vue CLI to build th
 * No real 404 status code - all requests are redirected with a status **200** to a single `index.html` endpoint, as the server generally does not know what endpoints exist on the app.
 :::
 
-## Statically generated websites
+## Statically Generated Websites
 
 Statically generated websites have an automatically generated static HTML file for each web page. Such applications are usually pre-built before being uploaded to the server, using dedicated site builders like [Vuepress](http://vuepress.vuejs.org/), [Gridsome](../ecosystem/gridsome.md), [Nuxt](../ecosystem/nuxt.md) or a tool like [Prerender SPA Plugin](../ecosystem/static-site-generators.md#prerender-spa-plugin).
  
@@ -153,7 +153,7 @@ You can read more on this topic in our [Static site generators](../ecosystem/sta
 * Not suitable for highly dynamic websites
 :::
 
-## SSR SPA websites
+## SSR SPA Websites
 
 Server-side rendered single-page applications are taking best of both worlds and applying them for a both SEO optimized and super fast loading websites. 
 
@@ -176,10 +176,10 @@ This whole process can be quite intimidating to setup, luckily frameworks like N
 * Expensive hosting - Hosting is generally more expensive as it requires a constantly running node server.
 :::
 
-## Coming from other technology
+## Coming from Other Technology
 
 ::: warning
-This page is still in early development. If you feel you can contribute, please dont hesitate to open a PR.
+This page is still in early development. If you feel you can contribute, please don't hesitate to open a PR.
 :::
 
 When coming from another technology, it is normal to compare common methods and patterns to those used in Vue.
@@ -227,7 +227,7 @@ In this section, we will go over the most popular technologies and the struggles
 
 ### Polymer
 
-### No framework - jQuery
+### No Framework - jQuery
 
 ## Usage with Backend Frameworks
 

--- a/docs/guide/learning/learning-platforms.md
+++ b/docs/guide/learning/learning-platforms.md
@@ -1,6 +1,6 @@
 # Learning platforms
 
-## Vue specific
+## Vue Specific
 A Vue specific learning platform is one that is solely focused on getting you up and running with Vue.js and its surrounding ecosystem. 
 
 These will focus on building Vue applications, best practices in the real world and usually go deeper into the framework.

--- a/docs/guide/learning/official-documentation.md
+++ b/docs/guide/learning/official-documentation.md
@@ -1,4 +1,4 @@
-# Official documentation
+# Official Documentation
 
 The official documentation for Vue.js is divided into several parts, spread across multiple websites covering different topics or core libraries such as [Vuex](https://vuex.vuejs.org), [Vue-Router](https://router.vuejs.org) or [SSR](https://ssr.vuejs.org) guides. All these pages have offline support and can be installed on a mobile phone.
 
@@ -18,7 +18,7 @@ However if you want to use `.vue` files while learning, read the [Single File Co
 
 To utilize SFC, you can create a [CodeSandbox](https://codesandbox.io/s/vue) project online or scaffold a new project locally using [Vue CLI](https://cli.vuejs.org/), which comes with its separate documentation.
 
-### Reactivity caveats
+### Reactivity Caveats
 
 Remember to read the [Reactivity in Depth](https://vuejs.org/v2/guide/reactivity.html) chapter which provides ways to deal with some caveats of Vue.js reactivity system, related to working with arrays and objects. This will all be solved in Vue 3 release.
 

--- a/docs/guide/learning/podcasts.md
+++ b/docs/guide/learning/podcasts.md
@@ -8,7 +8,7 @@
 
 Episodes can vary, from deep dive into Vue and its ecosystem, to more broader web development topics like testing, code automation, contributing to open source and others. Episodes are mostly free form style, around an hour long.
 
-## Fullstack radio
+## Full Stack Radio
 [Full Stack Radio](http://www.fullstackradio.com/) is an all-around general web development podcast. Episodes are hosted by Adam Wathan along with a guest, where they talk about everything from design and user experience to testing and system administration.
 
 ## Single episodes talking about Vue

--- a/docs/guide/learning/tips-from-mentors.md
+++ b/docs/guide/learning/tips-from-mentors.md
@@ -1,4 +1,4 @@
-# Tips from mentors
+# Tips from Mentors
 This chapter will give you an insight from Vue experts on how they began with Vue, how they approach learning new technologies and other helpful tips.
 
 ## Dobromir Hristov

--- a/docs/guide/learning/workshops.md
+++ b/docs/guide/learning/workshops.md
@@ -4,7 +4,7 @@
  
  Workshops usually work best in smaller groups, around 15 to 20 people, with larger ones usually requiring the help of additional mentors. Downside of larger groups is that attendees cannot interact as close with the lecturer, because of the amount of people the lecturer would need to address.
   
-## Format of a workshop
+## Format of a Workshop
 
 Every workshop is unique, as in each instructor decides on how to structure their event. The same workshop can be different each time it is held, depending on the attendees level, interaction and other factors.
 
@@ -14,7 +14,7 @@ Others follow the "work along with the mentor" approach, where attendees follow 
 
 Workshops mostly range from half a day to the more in depth ones spanning across two or three days. Longer workshops, allow for instructor to dive deeper into a topic, showing a lot more than just the basic requirements to get things working. Attendees have a bigger opportunity to interact with the mentors, ask questions on issues that come up as development goes.
 
-## Where to find workshops
+## Where to Find Workshops
 
 The easiest way is to check on [Events.vuejs.org - Workshops](https://events.vuejs.org/events/#workshops) as that page is officially maintained by core team members.
 


### PR DESCRIPTION
Official Vue docs use Title Case in their headers & side-nav links. 

Sometimes this repo used Title Case, sometimes sentence case, so this PR tries to standardize that. Otherwise it looks a little odd when browsing the navigation.

There are a few other minor fixes included, like missing apostrophes in contractions like `dont`, as well as properly formatting library/podcast/tool names.

Hope to make a more meaningful PR in the near future

![Done](https://raw.githubusercontent.com/jglovier/gifs/gh-pages/done/hand-wipe.gif)