### PR TITLE
fix: link correctly to blog.lichter.io

### DIFF
--- a/docs/guide/learning/blogs.md
+++ b/docs/guide/learning/blogs.md
@@ -68,7 +68,7 @@ This list consists of personal developer blogs, where people share their Vue rel
 
 - [Taha Shashtari](https://tahazsh.com/) -  Vue.js, JavaScript, CSS, Frontend development.
 
-- [Alexander Lichter](https://lichter.io/?ref=vuecommunity-guide) - Nuxt.js, Vue.js, JavaScript, Clean Code, Refactoring, SEO, Frontend, Tooling and Performance.
+- [Alexander Lichter](https://blog.lichter.io/?ref=vuecommunity-guide) - Nuxt.js, Vue.js, JavaScript, Clean Code, Refactoring, SEO, Frontend, Tooling and Performance.
 
 - [Jonas Galvez](https://hire.jonasgalvez.com.br) - JavaScript, Nuxt.js, Distributed Systems.
 


### PR DESCRIPTION
I've accidentally linked to my main page which is just the portfolio instead of the blog :see_no_evil: 	