### PR TITLE
feat: add search on documentation thanks to DocSearch

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -16,6 +16,10 @@ module.exports = {
   ],
   // serviceWorker: true,
   themeConfig: {
+    algolia: {
+      apiKey: '8c789b5d0ee680a4a383673877be347d',
+      indexName: 'vue-community'
+    },
     logo: '/logo_pin.png',
     docsDir: 'docs',
     repo: 'https://github.com/dobromir-hristov/vuecommunity',


### PR DESCRIPTION
This PR enable DocSearch since vuepress is supported. You can [find details about this feature here.](https://vuepress.vuejs.org/default-theme-config/#algolia-search)

Feel free to [check out our documentation regarding our project DocSearch](https://community.algolia.com/docsearch/).

Happy to give more details.

🚀 