### PR TITLE
Rewrite handling forms chapter

### DIFF
--- a/docs/guide/ecosystem/forms.md
+++ b/docs/guide/ecosystem/forms.md
@@ -92,7 +92,7 @@ The library has good documentation, high test coverage, and was the first fully 
 </useful-links-section>
 </useful-links>
 
-### Vue Formulate
+### Vue Formulate <badge text="Most Flexible"/>
 
 [Vue Formulate](https://github.com/wearebraid/vue-formulate) excels in its flexibility. You can treat it as a form generator or compose the forms directly in the template from provided components. Out of the box, it comes without the more complex components available for Vue-Form-Generator, but it's easy to create your own thanks to robust plugin and scoped slots architecture, which gives hopes for an ecosystem of 3rd party extensions in the future. You're also not bound to a specific CSS framework.
 

--- a/docs/guide/ecosystem/forms.md
+++ b/docs/guide/ecosystem/forms.md
@@ -192,14 +192,19 @@ Out of all kinds of form fields, multiselect is usually the most tricky to imple
 </useful-links>
 
 
-## Form Tutorials
+## Learning materials
 
-Here's a list of selected general tutorials on how to write forms in Vue.js that don't require using any specific library.
+Here's a list of selected general materials on how to write forms in Vue.js that don't require using any specific library.
 
 <useful-links>
 <useful-links-section title="Tutorials">
 
 * [An imperative guide to forms in Vue.js 2](https://logrocket.com/blog/an-imperative-guide-to-forms-in-vue-js-2/)
+
+</useful-links-section>
+<useful-links-section title="Books">
+
+* [Building Forms with Vue.js](https://vue-community.org/guide/learning/books.html#building-forms-with-vue-js)
 
 </useful-links-section>
 </useful-links>

--- a/docs/guide/ecosystem/forms.md
+++ b/docs/guide/ecosystem/forms.md
@@ -23,12 +23,12 @@ Here are the top pics from each category
 </useful-links-section>
 <useful-links-section title="Forms generator">
 
-[Vue Form Generator](#vue-form-generator)
+[Vue Form Generator](#vue-form-generator) - provides the most fields out of the box
 
 </useful-links-section>
-<useful-links-section title="Managing State">
+<useful-links-section title="Most flexible">
 
-[Vue-Final-Form](#vue-final-form)
+[Vue Formulate](#vue-formulate) - covers both form generator and state management use cases
 
 </useful-links-section>
 </useful-links>

--- a/docs/guide/ecosystem/forms.md
+++ b/docs/guide/ecosystem/forms.md
@@ -92,7 +92,7 @@ The library has good documentation, high test coverage, and was the first fully 
 </useful-links-section>
 </useful-links>
 
-### Vue-Formulate
+### Vue Formulate
 
 [Vue Formulate](https://github.com/wearebraid/vue-formulate) excels in its flexibility. You can treat it as a form generator or compose the forms directly in the template from provided components. Out of the box, it comes without the more complex components available for Vue-Form-Generator, but it's easy to create your own thanks to robust plugin and scoped slots architecture, which gives hopes for an ecosystem of 3rd party extensions in the future. You're also not bound to a specific CSS framework.
 

--- a/docs/guide/ecosystem/forms.md
+++ b/docs/guide/ecosystem/forms.md
@@ -128,7 +128,7 @@ Form state management libraries usually have smaller scope than form generators 
 
 ### Vue-Final-Form
 
-[Vue-Final-Form](https://github.com/egoist/vue-final-form) is a scoped slots based integration of Final Form, a framework-agnostic library that became pretty famous thanks to its subscription based state management system. Among its advantages are nice API and the focus on performance. Being written by [Egoist](https://twitter.com/_egoistlily), one of Vue.js Core Team members, will also be a plus for many.
+[Vue-Final-Form](https://github.com/egoist/vue-final-form) is a scoped slots based integration of Final Form, a framework-agnostic library that became pretty famous thanks to its subscription based state management system. Among its advantages are nice API and the focus on performance. Being written by [Egoist](https://twitter.com/_egoistlily), a Vue.js Core Team alumni, will also be a plus for many.
 
 <useful-links>
 <useful-links-section title="Official">

--- a/docs/guide/ecosystem/forms.md
+++ b/docs/guide/ecosystem/forms.md
@@ -79,15 +79,15 @@ Form generators are libraries that allow users to generate a set of form element
 
 ### Vue-Form-Generator
 
-[Vue-Form-Generator](https://github.com/icebob/vue-form-generator) is the most popular form generator for Vue.js. It uses an array based schema, it's own validation solution and a set of templates based on Bootstrap. You can use one of two builds - basic with most commonly used fields and full with all the bells and whistles the library has to offer. Both can be extended with your custom fields.
+[Vue-Form-Generator](https://github.com/icebob/vue-form-generator) is the most popular form generator for Vue.js. It uses an array based schema, it's own validation solution and a set of templates based on Bootstrap. You can use one of two builds - basic with most commonly used fields and the full one, with all the bells and whistles the library has to offer. Both can be extended with your custom fields.
 
-Having good documentation, high test coverage and being well-maintained for a long time, Vue-Form-Generator can be considered fully production ready.
+The library has good documentation, high test coverage, and was the first fully production ready project of its kind for Vue.
 
 <useful-links>
 <useful-links-section title="Official">
 
-* [GitHub Repo](https://github.com/icebob/vue-form-generator) 
-* [Docs](https://icebob.gitbooks.io/vueformgenerator/content)
+* [GitHub Repo](https://github.com/icebob/vue-form-generator)
+* [Docs](https://icebob.gitbooks.io/vueformgenerator)
 
 </useful-links-section>
 </useful-links>

--- a/docs/guide/ecosystem/forms.md
+++ b/docs/guide/ecosystem/forms.md
@@ -92,6 +92,21 @@ Having good documentation, high test coverage and being well-maintained for a lo
 </useful-links-section>
 </useful-links>
 
+### Vue-Formulate
+
+[Vue Formulate](https://github.com/wearebraid/vue-formulate) excels in its flexibility. You can treat it as a form generator or compose the forms directly in the template from provided components. Out of the box, it comes without the more complex components available for Vue-Form-Generator, but it's easy to create your own thanks to robust plugin and scoped slots architecture, which gives hopes for an ecosystem of 3rd party extensions in the future. You're also not bound to a specific CSS framework.
+
+The project is well maintained and offers extensive documentation, good internalization support, and built-in validators.
+
+<useful-links>
+<useful-links-section title="Official">
+
+* [GitHub Repo](https://github.com/wearebraid/vue-formulate)
+* [Docs](https://vueformulate.com)
+
+</useful-links-section>
+</useful-links>
+
 ### Vue-Formly
 
 [Vue-Formly](https://github.com/formly-js/vue-formly) takes obvious inspiration from [Angular-Formly](http://angular-formly.com). It's an older project, written originally for Vue 1, but now fully working with Vue 2. 

--- a/docs/guide/ecosystem/forms.md
+++ b/docs/guide/ecosystem/forms.md
@@ -75,7 +75,7 @@ With [Vuelidate](https://github.com/monterail/vuelidate) you don't validate your
 
 ## Form Generators
 
-Form generators are libraries that allow users to generate a set of form elements based on so called schema - data representation of form fields with support for various custom properties that are later applied to some more or less generic templates. There were multiple projects with an ambition to write an ideal form generator for Vue.js, but out of them, only two achieved the stage at which they're suitable for actual use.
+Form generators are libraries that allow users to generate a set of form elements based on so called schema - data representation of form fields with support for various custom properties that are later applied to some more or less generic templates. There were multiple projects with an ambition to write an ideal form generator for Vue.js, but out of them, the following ones achieved a state in which they're suitable for actual use.
 
 ### Vue-Form-Generator
 


### PR DESCRIPTION
The ecosystem situation changed since the chapter was originally written, so I suggest a bigger PR rewriting its structure, with some updates on older libraries.

**Not maintained libraries**

One of the things we didn't discuss in the past is how to approach libraries that stopped being maintained since the time they were initially covered. The final version of the rewrite should be based on that decision. There's also a possibility there's not really much to add to these libraries.

Some of our options:

- do nothing
- inform about it in the description
- remove them completely after they're not maintained for X time
- add a badge symbolizing lack of love from maintainers, possibly suggesting to step up and help out

**Categories**

Due to its flexibility, Vue Formulate fits into both our categories - form generators and form state management. That's why I'm not sure where to put it in the text if we stick to the original division.

Our state management category contains only not-maintained libraries at the very moment but there are libraries in the writing (don't worry, not mine) that will still fit one or another.

Anyways, I suggest a recommendation for Vue Formulate because of how flexible it is, probably in place of Vue Final Form.

**Books**

I rewrote the section about tutorials to learning materials, so it can also cover Marina's book description on the Books page. Unlike testing which deserved its own category, I don't think we'll get more form-only books in the upcoming future so just adding a link to our description made sense for me.