### PR TITLE
Update Ionic info and add notes on Capacitor

### DIFF
--- a/docs/guide/ecosystem/mobile-apps.md
+++ b/docs/guide/ecosystem/mobile-apps.md
@@ -217,6 +217,33 @@ Quasar comes with a CLI for managing and bundling your mobile app for each platf
 </useful-links-section>
 </useful-links>
 
+### Ionic Vue <badge text="New"/>
+
+One of the most popular mobile UI frameworks in the world, Ionic was originally built for Angular, but with their latest release they now support Vue 3, thanks to their [move to web components](https://blog.ionicframework.com/introducing-ionic-4-ionic-for-everyone/). 
+
+Ionic has a vast community, but as most tutorials are for the previous versions, using Angular, Vue users might have to adopt the examples, but the concepts are the same. New material covering Ionic Vue specifically is slowly emerging now that it has finished beta.
+
+As with other frameworks, it provides a set of components that change look depending on the OS they are built for.
+
+::: warning Keep in mind
+* Very young and small community still
+:::
+
+<useful-links>
+<useful-links-section title="Official">
+* [Ionic Vue Docs](https://ionicframework.com/docs/vue/overview)
+* [Announcing Ionic Vue](https://ionicframework.com/blog/announcing-ionic-vue)
+</useful-links-section>
+
+<useful-links-section title="Tutorials">
+* [Build a chat app using Framework7](https://ionicframework.com/blog/new-tutorial-your-first-ionic-vue-app)
+</useful-links-section>
+
+<useful-links-section title="Videos">
+* [Mobile apps with Vue and Ionic](https://www.youtube.com/watch?v=bJKwPsOqcqM)
+</useful-links-section>
+</useful-links>
+
 ### Framework 7
 
 Framework 7 is an already established, mobile focused UI framework, offering native like looking themes for both IOS and Android. It was originally built with IOS in mind, with Material Design added later.
@@ -255,24 +282,3 @@ They have a nice documentation, though the Vue part is lacking a bit on explanat
 ::: contribute
 :::
 
-### Ionic Vue <badge text="Beta" type="error"/>
-
-One of the most popular mobile UI frameworks in the world, Ionic was originally built for Angular, but with their latest release they support Vue, thanks to their [move to web components](https://blog.ionicframework.com/introducing-ionic-4-ionic-for-everyone/). 
-
-Keep in mind their Vue implementation is still in **Beta** and is yet to be ironed out. Ionic has a vast community, but as most tutorials are for the previous versions, using Angular, Vue users might have to adopt the examples, but the concept is the same.
-
-As with other frameworks, it provides a set of components that change look depending on the OS they are built for.
-
-::: warning Keep in mind
-* Still in Beta and developed
-* Very young and little to no community around it
-* Almost no docs or learning material
-:::
-
-<useful-links>
-<useful-links-section title="Official">
-
-* [A Vue from Ionic](https://blog.ionicframework.com/a-vue-from-ionic/)
-
-</useful-links-section>
-</useful-links>

--- a/docs/guide/ecosystem/mobile-apps.md
+++ b/docs/guide/ecosystem/mobile-apps.md
@@ -236,7 +236,7 @@ As with other frameworks, it provides a set of components that change look depen
 </useful-links-section>
 
 <useful-links-section title="Tutorials">
-* [Build a chat app using Framework7](https://ionicframework.com/blog/new-tutorial-your-first-ionic-vue-app)
+* [Your First Ionic Vue App](https://ionicframework.com/blog/new-tutorial-your-first-ionic-vue-app)
 </useful-links-section>
 
 <useful-links-section title="Videos">

--- a/docs/guide/ecosystem/mobile-apps.md
+++ b/docs/guide/ecosystem/mobile-apps.md
@@ -166,7 +166,7 @@ Below is a list of popular tools to generate a PWA quickly:
 
 ## Hybrid Apps
 
-Hybrid apps are built by reusing already establishes knowledge about making websites using HTML, CSS and JavaScript with a minimal extra learning curve. SPA's can be converted to mobile apps with a tool called Cordova. It acts as a wrapper around your web app by providing access to device hardware and functions via a unified JavaScript API. It allows developers to write one code that can run on all platforms.
+Hybrid apps are built by reusing well established tools for making websites like HTML, CSS and JavaScript with a minimal extra learning curve. These web based projects can then be compiled to native cross-platform applications with build tools such as (Cordova)[https://cordova.apache.org] or it's more recent successor (Capacitor)[https://capacitorjs.com]. The build tool wraps the web app in a native shell and provides access to native device functionality via unified JavaScript APIs. This allows developers to write one code base that can then run natively across platforms.
 
 ::: tip Pros
 * Uses plain HTML, CSS and JavaScript
@@ -192,9 +192,9 @@ Some frameworks focus more towards one platform, so careful consideration must b
 
 ### Quasar <badge text="Popular"/>
 
-Quasar is a very active and fast growing Vue UI framework, one of the first targeting desktop and mobile in particular. It offers a large and ever extending set of pre-built components, some mimic mobile elements, and a bunch of other useful general use case ones. 
+Quasar is a very active and fast growing Vue UI framework, one of the first targeting desktop and mobile in particular. It offers a large and ever extending set of pre-built components, some mimic mobile elements, and a bunch of other useful general use case ones.
 
-Quasar comes with a CLI for managing and bundling your mobile app for each platform, using PhoneGap. CLI allows easy application bootstrapping, with support for PWA, i18n, Vuex, VueRouter, Async Code splitting and more.
+Quasar comes with a CLI for managing and bundling your mobile app for each platform, using PhoneGap. CLI allows easy application bootstrapping, with support for PWA, i18n, Vuex, VueRouter, Async Code splitting, option of Cordova or Capacitor for native builds and more.
 
 <useful-links>
 <useful-links-section title="Official">
@@ -223,7 +223,7 @@ One of the most popular mobile UI frameworks in the world, Ionic was originally 
 
 Ionic has a vast community, but as most tutorials are for the previous versions, using Angular, Vue users might have to adopt the examples, but the concepts are the same. More new material targeting Ionic Vue is starting to emerge gradually now that it has finished beta.
 
-As with other frameworks, it provides a set of components that change look depending on the OS they are built for.
+As with other frameworks, it provides a set of components that change look depending on the OS they are built for and a CLI tool for starting projects and easily integrating Capacitor for native builds.
 
 ::: warning Keep in mind
 * Young and small community still
@@ -248,7 +248,7 @@ As with other frameworks, it provides a set of components that change look depen
 
 Framework 7 is an already established, mobile focused UI framework, offering native like looking themes for both IOS and Android. It was originally built with IOS in mind, with Material Design added later.
 
-They officially support Vue on top of their components. Along with mobile apps, you can easily develop Web Apps (SPA) with PWA support via their CLI.
+They officially support Vue on top of their components. Along with mobile apps using Capacitor, you can easily develop Web Apps (SPA) with PWA support via their CLI.
 
 They have a nice documentation, though the Vue part is lacking a bit on explanations, so jumping between it and standard component docs may be necessary.
 

--- a/docs/guide/ecosystem/mobile-apps.md
+++ b/docs/guide/ecosystem/mobile-apps.md
@@ -179,7 +179,7 @@ Hybrid apps are built by reusing well established tools for making websites like
 
 ::: danger Cons
 * Generally slower than Native apps
-* Access to lower level device APIs is dependent on wrapper (Cordova)
+* Access to lower level device APIs is dependent on wrapper (Cordova or Capacitor)
 * Platform inconsistencies
 :::
 
@@ -227,7 +227,7 @@ Ionic has a vast community, but as most tutorials are for the previous versions,
 As with other frameworks, it provides a set of components that change look depending on the OS they are built for and a CLI tool for starting projects and easily integrating Capacitor for native builds.
 
 ::: warning Keep in mind
-* Young and small community still
+* Still young and small community
 :::
 
 <useful-links>

--- a/docs/guide/ecosystem/mobile-apps.md
+++ b/docs/guide/ecosystem/mobile-apps.md
@@ -253,7 +253,7 @@ As with other frameworks, it provides a set of components that change look depen
 
 Framework 7 is an already established, mobile focused UI framework, offering native like looking themes for both IOS and Android. It was originally built with IOS in mind, with Material Design added later.
 
-They officially support Vue on top of their components. Along with mobile apps using Capacitor, you can easily develop Web Apps (SPA) with PWA support via their CLI.
+They officially support Vue on top of their components. Along with mobile apps using Cordova, you can easily develop Web Apps (SPA) with PWA support via their CLI.
 
 They have a nice documentation, though the Vue part is lacking a bit on explanations, so jumping between it and standard component docs may be necessary.
 

--- a/docs/guide/ecosystem/mobile-apps.md
+++ b/docs/guide/ecosystem/mobile-apps.md
@@ -23,7 +23,8 @@ On this page, we will go through the different ways one can build a mobile app w
 </useful-links-section>
 <useful-links-section title="Hybrid Apps">
 
-[Quasar](#quasar-badge-textpopular)
+* [Quasar](#quasar)
+* [Ionic Vue](#ionic-vue)
 
 </useful-links-section>
 <useful-links-section title="PWA">
@@ -221,7 +222,7 @@ Quasar comes with a CLI for managing and bundling your mobile app for each platf
 
 One of the most popular mobile UI frameworks in the world, Ionic was originally built for Angular, but with their latest release they now support Vue 3, thanks to their [move to web components](https://blog.ionicframework.com/introducing-ionic-4-ionic-for-everyone/). 
 
-Ionic has a vast community, but as most tutorials are for the previous versions, using Angular, Vue users might have to adopt the examples, but the concepts are the same. More new material targeting Ionic Vue is starting to emerge gradually now that it has finished beta.
+Ionic has a vast community, but as most tutorials are for the previous versions, using Angular, Vue users might have to adopt the examples, but the concepts are the same. New material targeting Ionic Vue is starting to emerge gradually now that it has finished beta.
 
 As with other frameworks, it provides a set of components that change look depending on the OS they are built for and a CLI tool for starting projects and easily integrating Capacitor for native builds.
 
@@ -231,16 +232,20 @@ As with other frameworks, it provides a set of components that change look depen
 
 <useful-links>
 <useful-links-section title="Official">
+  
 * [Ionic Vue Docs](https://ionicframework.com/docs/vue/overview)
 * [Announcing Ionic Vue](https://ionicframework.com/blog/announcing-ionic-vue)
-</useful-links-section>
 
+</useful-links-section>
 <useful-links-section title="Tutorials">
+  
 * [Your First Ionic Vue App](https://ionicframework.com/blog/new-tutorial-your-first-ionic-vue-app)
-</useful-links-section>
 
+</useful-links-section>
 <useful-links-section title="Videos">
+  
 * [Mobile apps with Vue and Ionic](https://www.youtube.com/watch?v=bJKwPsOqcqM)
+
 </useful-links-section>
 </useful-links>
 

--- a/docs/guide/ecosystem/mobile-apps.md
+++ b/docs/guide/ecosystem/mobile-apps.md
@@ -233,7 +233,8 @@ As with other frameworks, it provides a set of components that change look depen
 <useful-links>
 <useful-links-section title="Official">
   
-* [Ionic Vue Docs](https://ionicframework.com/docs/vue/overview)
+* [Ionic Vue Documentation](https://ionicframework.com/docs/vue/overview)
+* [Ionic Components](https://ionicframework.com/docs/components)
 * [Announcing Ionic Vue](https://ionicframework.com/blog/announcing-ionic-vue)
 
 </useful-links-section>

--- a/docs/guide/ecosystem/mobile-apps.md
+++ b/docs/guide/ecosystem/mobile-apps.md
@@ -226,7 +226,7 @@ Ionic has a vast community, but as most tutorials are for the previous versions,
 As with other frameworks, it provides a set of components that change look depending on the OS they are built for.
 
 ::: warning Keep in mind
-* Very young and small community still
+* Young and small community still
 :::
 
 <useful-links>

--- a/docs/guide/ecosystem/mobile-apps.md
+++ b/docs/guide/ecosystem/mobile-apps.md
@@ -221,7 +221,7 @@ Quasar comes with a CLI for managing and bundling your mobile app for each platf
 
 One of the most popular mobile UI frameworks in the world, Ionic was originally built for Angular, but with their latest release they now support Vue 3, thanks to their [move to web components](https://blog.ionicframework.com/introducing-ionic-4-ionic-for-everyone/). 
 
-Ionic has a vast community, but as most tutorials are for the previous versions, using Angular, Vue users might have to adopt the examples, but the concepts are the same. New material covering Ionic Vue specifically is slowly emerging now that it has finished beta.
+Ionic has a vast community, but as most tutorials are for the previous versions, using Angular, Vue users might have to adopt the examples, but the concepts are the same. More new material targeting Ionic Vue is starting to emerge gradually now that it has finished beta.
 
 As with other frameworks, it provides a set of components that change look depending on the OS they are built for.
 

--- a/docs/guide/ecosystem/mobile-apps.md
+++ b/docs/guide/ecosystem/mobile-apps.md
@@ -167,7 +167,7 @@ Below is a list of popular tools to generate a PWA quickly:
 
 ## Hybrid Apps
 
-Hybrid apps are built by reusing well established tools for making websites like HTML, CSS and JavaScript with a minimal extra learning curve. These web based projects can then be compiled to native cross-platform applications with build tools such as (Cordova)[https://cordova.apache.org] or it's more recent successor (Capacitor)[https://capacitorjs.com]. The build tool wraps the web app in a native shell and provides access to native device functionality via unified JavaScript APIs. This allows developers to write one code base that can then run natively across platforms.
+Hybrid apps are built by reusing well established tools for making websites like HTML, CSS and JavaScript with a minimal extra learning curve. These web based projects can then be compiled to native mobile apps with build tools such as (Cordova)[https://cordova.apache.org] or it's more recent successor (Capacitor)[https://capacitorjs.com]. The build tool wraps the web app in a native shell and provides access to native device functionality via unified JavaScript APIs. This allows developers to write one code base that can then run natively across platforms.
 
 ::: tip Pros
 * Uses plain HTML, CSS and JavaScript

--- a/docs/guide/ecosystem/mobile-apps.md
+++ b/docs/guide/ecosystem/mobile-apps.md
@@ -233,8 +233,8 @@ As with other frameworks, it provides a set of components that change look depen
 <useful-links>
 <useful-links-section title="Official">
   
-* [Ionic Vue Documentation](https://ionicframework.com/docs/vue/overview)
-* [Ionic Components](https://ionicframework.com/docs/components)
+* [Documentation](https://ionicframework.com/docs/vue/overview)
+* [Components](https://ionicframework.com/docs/components)
 * [Announcing Ionic Vue](https://ionicframework.com/blog/announcing-ionic-vue)
 
 </useful-links-section>

--- a/docs/guide/ecosystem/ui-libraries.md
+++ b/docs/guide/ecosystem/ui-libraries.md
@@ -356,7 +356,7 @@ Ionic is an open source UI toolkit focused on building high quality cross platfo
 <useful-links>
 <useful-links-section title="Official">
 
-* [Ionic Vue repository](https://github.com/ionic-team/ionic-framework/tree/master/packages/vue)
+* [Ionic Vue components](https://ionicframework.com/docs/components)
 * [Ionic Vue documentation](https://ionicframework.com/docs/vue/overview)
 * [Ionic Vue forum](https://forum.ionicframework.com/c/ionic/vue/29)
 

--- a/docs/guide/ecosystem/ui-libraries.md
+++ b/docs/guide/ecosystem/ui-libraries.md
@@ -19,19 +19,25 @@ If you don't have time to read all of this and just need a quick answer:
 <useful-links>
 <useful-links-section title="Users choice">
 
-[Vuetify](#vuetify) - mobile and desktop ready, material design.
-[Quasar](#quasar) - also a material design framework, but with cross-platform capabilities.
+ * [Vuetify](#vuetify) - mobile and desktop ready, material design
+ * [Quasar](#quasar) - also a material design framework, but with cross-platform capabilities
 
 </useful-links-section>
-<useful-links-section title="Desktop mainly">
+<useful-links-section title="Any platform">
+
+ * [Quasar](#quasar) - all-in-one framework, option of Cordova or Capacitor for mobile builds
+ * [Ionic Vue](#ionic-vue) - UI toolkit built on top of Vue CLI, uses Capacitor for native mobile
+
+</useful-links-section>
+<useful-links-section title="Desktop focused">
 
  - [Element UI](#element-ui) - extensive, desktop oriented, widely popular in asia
  - [iView](#iview)
 
 </useful-links-section>
-<useful-links-section title="Easy get into">
+<useful-links-section title="Easy if familiar">
 
-* [Bootstrap-Vue](#bootstrap-vue) - Bootstrap based
+* [BootstrapVue](#bootstrapvue) - Bootstrap based
 * [Buefy](#buefy) - Bulma based
 
 </useful-links-section>

--- a/docs/guide/ecosystem/ui-libraries.md
+++ b/docs/guide/ecosystem/ui-libraries.md
@@ -351,7 +351,7 @@ Inkline provides you with over 50 customizable components, hundreds of utility c
 
 > A native Vue version of Ionic Framework that makes it easy to build apps for iOS, Android, and the web as a Progressive Web App. Our components allow developers to build native experiences, all while using web technology.
 
-Ionic is an open source UI toolkit focused on building high quality cross platform apps. Originally built for Angular and already one of the most popular frameworks in the world, the latest release now supports Vue as well as React thanks to their [move to native web components](https://blog.ionicframework.com/introducing-ionic-4-ionic-for-everyone) in version 4. The Ionic team reports the framework powers roughly [15% of all mobile apps](https://appfigures.com/top-sdks/development/apps).
+Ionic is an open source UI toolkit focused on building high quality cross platform apps. Originally built for Angular and already one of the most popular frameworks in the world, the latest release now supports Vue 3 as well as React thanks to their [move to native web components](https://blog.ionicframework.com/introducing-ionic-4-ionic-for-everyone) in version 4. The Ionic team reports the framework powers roughly [15% of all mobile apps](https://appfigures.com/top-sdks/development/apps).
 
 <useful-links>
 <useful-links-section title="Official">

--- a/docs/guide/ecosystem/ui-libraries.md
+++ b/docs/guide/ecosystem/ui-libraries.md
@@ -351,7 +351,7 @@ Inkline provides you with over 50 customizable components, hundreds of utility c
 
 > A native Vue version of Ionic Framework that makes it easy to build apps for iOS, Android, and the web as a Progressive Web App. Our components allow developers to build native experiences, all while using web technology.
 
-Ionic is an open source UI toolkit focused on building high quality mobile apps for native iOS, native Android, and the web. It is one of the most popular frameworks in the world, originally built for Angular, the latest release now supports Vue as well as React thanks to their [move to native web components](https://blog.ionicframework.com/introducing-ionic-4-ionic-for-everyone). The Ionic team reports the framework powers roughly (15% of all mobile apps)[https://appfigures.com/top-sdks/development/apps].
+Ionic is an open source UI toolkit focused on building high quality cross platform apps. Originally built for Angular and already one of the most popular frameworks in the world, the latest release now supports Vue as well as React thanks to their [move to native web components](https://blog.ionicframework.com/introducing-ionic-4-ionic-for-everyone) in version 4. The Ionic team reports the framework powers roughly (15% of all mobile apps)[https://appfigures.com/top-sdks/development/apps].
 
 <useful-links>
 <useful-links-section title="Official">

--- a/docs/guide/ecosystem/ui-libraries.md
+++ b/docs/guide/ecosystem/ui-libraries.md
@@ -174,8 +174,8 @@ While not as well-known as Element UI, Iview is a valid, well maintained alterna
 <useful-links>
 <useful-links-section title="Official">
 
-* [Iview repository](https://github.com/iview/iview)
-* [Iview documentation](https://iviewui.com)
+* [iView repository](https://github.com/iview/iview)
+* [iView documentation](https://iviewui.com)
 
 </useful-links-section>
 </useful-links>

--- a/docs/guide/ecosystem/ui-libraries.md
+++ b/docs/guide/ecosystem/ui-libraries.md
@@ -1,4 +1,4 @@
-# UI libraries
+# UI Libraries
 
 _"Which UI library is the best"_ stands among the most common questions from newcomers to Vue.js ecosystem. The answer isn't easy though, since there is no such thing as "the best" components library for Vue, due to many factors that should be considered. What you can look for instead is a solution optimal for your specific use case.
 
@@ -249,7 +249,7 @@ Despite its popularity, [Semantic UI](https://semantic-ui.com/) never really hit
 </useful-links-section>
 </useful-links>
 
-### vectre
+### Vectre
 
 [Specter.CSS](https://picturepan2.github.io/spectre/) is a lightweight, responsive and modern CSS framework for faster and extensible development. The hallmark of this framework is its tiny size and consistent design language. But up to this point, there has been no full implementation of most of the components in any ecosystem. This was the motivation to create a fast, small and user friendly Vectre framework that will have modern features like typescript/tsx support, tree shaking, multiple JavaScript module systems and of course tiny size.
 
@@ -351,7 +351,7 @@ Inkline provides you with over 50 customizable components, hundreds of utility c
 
 > A native Vue version of Ionic Framework that makes it easy to build apps for iOS, Android, and the web as a Progressive Web App. Our components allow developers to build native experiences, all while using web technology.
 
-Ionic is an open source UI toolkit focused on building high quality cross platform apps. Originally built for Angular and already one of the most popular frameworks in the world, the latest release now supports Vue as well as React thanks to their [move to native web components](https://blog.ionicframework.com/introducing-ionic-4-ionic-for-everyone) in version 4. The Ionic team reports the framework powers roughly (15% of all mobile apps)[https://appfigures.com/top-sdks/development/apps].
+Ionic is an open source UI toolkit focused on building high quality cross platform apps. Originally built for Angular and already one of the most popular frameworks in the world, the latest release now supports Vue as well as React thanks to their [move to native web components](https://blog.ionicframework.com/introducing-ionic-4-ionic-for-everyone) in version 4. The Ionic team reports the framework powers roughly [15% of all mobile apps](https://appfigures.com/top-sdks/development/apps).
 
 <useful-links>
 <useful-links-section title="Official">

--- a/docs/guide/ecosystem/ui-libraries.md
+++ b/docs/guide/ecosystem/ui-libraries.md
@@ -72,7 +72,7 @@ The components in libraries such as [Vuetify](#vuetify) or [Vue-Material](#vue-m
 
 > Vuetify is a semantic component framework for Vue. It aims to provide clean, semantic and reusable components that make building your application a breeze. Build amazing applications with the power of Vue, Material Design and a massive library of beautifully crafted components and features.
 
-Vuetify is praised not only for a wide selection of components, but also for the way it's maintained. Currently it's developed by a full team of developers and it's got big and well organized community. The project is funded via Patreon and Open Collective.
+Vuetify is praised not only for a wide selection of components, but also for the way it's maintained. Currently it's developed by a full team of developers and it's got a big and well organized community. The project is funded via Patreon and Open Collective.
 
 The library's ecosystem provides multiple tools, such as theme generator, Webpack loader or opinionated Eslint config. It's also easy to implement Vuetify in your application thanks to provided plugins for Vue CLI and Nuxt.
 
@@ -343,6 +343,27 @@ Inkline provides you with over 50 customizable components, hundreds of utility c
 * [Inkline repository](https://github.com/inkline/inkline) 
 * [Inkline documentation](https://inkline.io/) 
 * [Inkline chat on Discord](https://discord.gg/2w5UGnK)
+
+</useful-links-section>
+</useful-links>
+
+### Ionic Vue <badge text="Web Native"/>
+
+> A native Vue version of Ionic Framework that makes it easy to build apps for iOS, Android, and the web as a Progressive Web App. Our components allow developers to build native experiences, all while using web technology.
+
+Ionic is an open source UI toolkit focused on building high quality mobile apps for native iOS, native Android, and the web. It is one of the most popular frameworks in the world, originally built for Angular, the latest release now supports Vue as well as React thanks to their [move to native web components](https://blog.ionicframework.com/introducing-ionic-4-ionic-for-everyone). The Ionic team reports the framework powers roughly (15% of all mobile apps)[https://appfigures.com/top-sdks/development/apps].
+
+<useful-links>
+<useful-links-section title="Official">
+
+* [Ionic Vue repository](https://github.com/ionic-team/ionic-framework/tree/master/packages/vue)
+* [Ionic Vue documentation](https://ionicframework.com/docs/vue/overview)
+* [Ionic Vue forum](https://forum.ionicframework.com/c/ionic/vue/29)
+
+</useful-links-section>
+<useful-links-section title="Tutorials">
+
+* [Your First Ionic Vue App](https://ionicframework.com/blog/new-tutorial-your-first-ionic-vue-app)
 
 </useful-links-section>
 </useful-links>

--- a/docs/guide/ecosystem/ui-libraries.md
+++ b/docs/guide/ecosystem/ui-libraries.md
@@ -169,7 +169,7 @@ The library's success resulted in porting Element UI to Angular and React ecosys
 
 ### iView
 
-While not as well-known as Element UI, Iview is a valid, well maintained alternative. It provides a large set of components which we can import on demand and useful tools to make working with them easier, together with Typescript support and the official admin panel template. It's a good choice especially if you prefer to work with LESS over SASS.
+While not as well-known as Element UI, iView is a valid, well maintained alternative. It provides a large set of components which we can import on demand and useful tools to make working with them easier, together with Typescript support and the official admin panel template. It's a good choice especially if you prefer to work with LESS over SASS.
 
 <useful-links>
 <useful-links-section title="Official">

--- a/docs/guide/ecosystem/ui-libraries.md
+++ b/docs/guide/ecosystem/ui-libraries.md
@@ -20,13 +20,13 @@ If you don't have time to read all of this and just need a quick answer:
 <useful-links-section title="Users choice">
 
  * [Vuetify](#vuetify) - mobile and desktop ready, material design
- * [Quasar](#quasar) - also a material design framework, but with cross-platform capabilities
+ * [Quasar](#quasar) - material design as well but with cross-platform capabilities
 
 </useful-links-section>
 <useful-links-section title="Any platform">
 
- * [Quasar](#quasar) - all-in-one framework, option of Cordova or Capacitor for mobile builds
- * [Ionic Vue](#ionic-vue) - UI toolkit built on top of Vue CLI, uses Capacitor for native mobile
+ * [Quasar](#quasar) - full framework, option of Cordova or Capacitor for mobile builds
+ * [Ionic Vue](#ionic-vue) - cross-platform UI toolkit, uses Capacitor for native mobile
 
 </useful-links-section>
 <useful-links-section title="Desktop focused">


### PR DESCRIPTION
- Remove beta status and update details and links for Ionic Vue
- Add 'Any platform' shortcuts and an Ionic Vue entry to UI Libraries section
- Add notes about Capacitor and which build tool each project uses
- Propose to move Ionic Vue above Framework 7 in Hybrid Apps list as it has already surpassed in npm downloads
- A few other tiny stray fixes