### PR TITLE
Add basic info for Conferences page

### DIFF
--- a/docs/guide/community/conferences.md
+++ b/docs/guide/community/conferences.md
@@ -10,7 +10,7 @@
 
 Here we will list Vue Conferences around the world and what is unique about them.
 
-### VueConf US
+## VueConf US
 
 Hosted by Evan You
 
@@ -23,7 +23,7 @@ Hosted by Evan You
 </useful-links>
 
 
-### Vue.js Amsterdam
+## Vue.js Amsterdam
 
 > Vuejs Amsterdam is the Largest & Most Epic Vue Conference in the World
 
@@ -36,7 +36,7 @@ Hosted by Evan You
 </useful-links-section>
 </useful-links>
 
-### VueConf Toronto
+## VueConf Toronto
 
 > Join 10,000+ Vue.js developers from more than 100 countries for a two-day conference to learn and discuss about the latest of Vue.js and related technologies
 
@@ -49,7 +49,7 @@ Hosted by Evan You
 </useful-links-section>
 </useful-links>
 
-### Vue.js London
+## Vue.js London
 
 <useful-links>
 <useful-links-section title="Links">

--- a/docs/guide/community/conferences.md
+++ b/docs/guide/community/conferences.md
@@ -15,8 +15,6 @@
 
 Here we will list Vue Conferences around the world and what is unique about them.
 
-## 
-
 ## VueConf US
 
 Hosted by Evan You

--- a/docs/guide/community/conferences.md
+++ b/docs/guide/community/conferences.md
@@ -27,6 +27,18 @@ Hosted by Evan You
 </useful-links-section>
 </useful-links>
 
+## VueConf Toronto
+
+> Join 10,000+ Vue.js developers from more than 100 countries for a two-day conference to learn and discuss about the latest of Vue.js and related technologies
+
+<useful-links>
+<useful-links-section title="Links">
+
+- [vuetoronto.com](https://vuetoronto.com/)
+- [YouTube Channel](https://www.youtube.com/c/VueConfToronto)
+
+</useful-links-section>
+</useful-links>
 
 ## Vue.js Amsterdam
 
@@ -38,19 +50,6 @@ Hosted by Evan You
 - [vuejs.amsterdam](https://vuejs.amsterdam)
 - [YouTube Channel](https://www.youtube.com/c/VuejsAmsterdam)
   
-</useful-links-section>
-</useful-links>
-
-## VueConf Toronto
-
-> Join 10,000+ Vue.js developers from more than 100 countries for a two-day conference to learn and discuss about the latest of Vue.js and related technologies
-
-<useful-links>
-<useful-links-section title="Links">
-
-- [vuetoronto.com](https://vuetoronto.com/)
-- [YouTube Channel](https://www.youtube.com/c/VueConfToronto)
-
 </useful-links-section>
 </useful-links>
 

--- a/docs/guide/community/conferences.md
+++ b/docs/guide/community/conferences.md
@@ -6,9 +6,16 @@
 - [Vue Conference Videos By Vue Mastery](https://www.vuemastery.com/conferences)
 
 </useful-links-section>
+<useful-links-section title="See also">
+
+- [Vue.js Events](events.vuejs.org) - Official events and community portal
+
+</useful-links-section>
 </useful-links>
 
 Here we will list Vue Conferences around the world and what is unique about them.
+
+## 
 
 ## VueConf US
 

--- a/docs/guide/community/conferences.md
+++ b/docs/guide/community/conferences.md
@@ -8,9 +8,9 @@
 </useful-links-section>
 </useful-links>
 
-Here we will list Vue Conferences around the world, when each is held and what is unique about it.
+Here we will list Vue Conferences around the world and what is unique about them.
 
-### VueConf US (Apr)
+### VueConf US
 
 Hosted by Evan You
 
@@ -23,7 +23,7 @@ Hosted by Evan You
 </useful-links>
 
 
-### Vue.js Amsterdam (Jan)
+### Vue.js Amsterdam
 
 > Vuejs Amsterdam is the Largest & Most Epic Vue Conference in the World
 
@@ -36,7 +36,7 @@ Hosted by Evan You
 </useful-links-section>
 </useful-links>
 
-### VueConf Toronto (Nov)
+### VueConf Toronto
 
 > Join 10,000+ Vue.js developers from more than 100 countries for a two-day conference to learn and discuss about the latest of Vue.js and related technologies
 
@@ -49,7 +49,7 @@ Hosted by Evan You
 </useful-links-section>
 </useful-links>
 
-### Vue.js London (tbd)
+### Vue.js London
 
 <useful-links>
 <useful-links-section title="Links">

--- a/docs/guide/community/conferences.md
+++ b/docs/guide/community/conferences.md
@@ -1,6 +1,63 @@
 # Conferences
 
+<useful-links>
+<useful-links-section title="Video archive">
+
+- [Vue Conference Videos By Vue Mastery](https://www.vuemastery.com/conferences)
+
+</useful-links-section>
+</useful-links>
+
+Here we will list Vue Conferences around the world, when each is held and what is unique about it.
+
+### VueConf US (Apr)
+
+Hosted by Evan You
+
+<useful-links>
+<useful-links-section title="Links">
+
+- [us.vuejs.org](https://us.vuejs.org)
+
+</useful-links-section>
+</useful-links>
+
+
+### Vue.js Amsterdam (Jan)
+
+> Vuejs Amsterdam is the Largest & Most Epic Vue Conference in the World
+
+<useful-links>
+<useful-links-section title="Links">
+  
+- [vuejs.amsterdam](https://vuejs.amsterdam)
+- [YouTube Channel](https://www.youtube.com/c/VuejsAmsterdam)
+  
+</useful-links-section>
+</useful-links>
+
+### VueConf Toronto (Nov)
+
+> Join 10,000+ Vue.js developers from more than 100 countries for a two-day conference to learn and discuss about the latest of Vue.js and related technologies
+
+<useful-links>
+<useful-links-section title="Links">
+
+- [vuetoronto.com](https://vuetoronto.com/)
+- [YouTube Channel](https://www.youtube.com/c/VueConfToronto)
+
+</useful-links-section>
+</useful-links>
+
+### Vue.js London (tbd)
+
+<useful-links>
+<useful-links-section title="Links">
+
+[vuejs.london](https://vuejs.london)
+
+</useful-links-section>
+</useful-links>
+
 ::: contribute
 :::
-
-Here we will list Vue Conferences, how each was held and what was unique about it.

--- a/docs/guide/ecosystem/mobile-apps.md
+++ b/docs/guide/ecosystem/mobile-apps.md
@@ -281,7 +281,7 @@ They have a nice documentation, though the Vue part is lacking a bit on explanat
 ### Onsen UI
 
 ::: contribute
-:::..
+:::
 
 ### Mint UI
 

--- a/docs/guide/ecosystem/mobile-apps.md
+++ b/docs/guide/ecosystem/mobile-apps.md
@@ -195,7 +195,7 @@ Some frameworks focus more towards one platform, so careful consideration must b
 
 Quasar is a very active and fast growing Vue UI framework, one of the first targeting desktop and mobile in particular. It offers a large and ever extending set of pre-built components, some mimic mobile elements, and a bunch of other useful general use case ones.
 
-Quasar comes with a CLI for managing and bundling your mobile app for each platform, using PhoneGap. CLI allows easy application bootstrapping, with support for PWA, i18n, Vuex, VueRouter, Async Code splitting, option of Cordova or Capacitor for native builds and more.
+Quasar comes with a CLI for easy application bootstrapping, managing, and bundling your mobile app for each platform. Integrates many tools into a full featured framework including easy setup for PWA, i18n, Vuex, VueRouter, Async Code splitting, option of Cordova or Capacitor for native builds and more.
 
 <useful-links>
 <useful-links-section title="Official">

--- a/docs/guide/ecosystem/mobile-apps.md
+++ b/docs/guide/ecosystem/mobile-apps.md
@@ -195,7 +195,7 @@ Some frameworks focus more towards one platform, so careful consideration must b
 
 Quasar is a very active and fast growing Vue UI framework, one of the first targeting desktop and mobile in particular. It offers a large and ever extending set of pre-built components, some mimic mobile elements, and a bunch of other useful general use case ones.
 
-Quasar comes with a CLI for easy application bootstrapping, managing, and bundling your mobile app for each platform. Integrates many tools into a full featured framework including easy setup for PWA, i18n, Vuex, VueRouter, Async Code splitting, option of Cordova or Capacitor for native builds and more.
+Quasar comes with a CLI for easy application bootstrapping, managing, and bundling your mobile app for each platform. Integrates many tools into a full featured framework including support for PWAs, i18n, Vuex, Vue Router, code splitting, option of Cordova or Capacitor for native builds and more.
 
 <useful-links>
 <useful-links-section title="Official">


### PR DESCRIPTION
Fixes #16
- Add headings and links to Conferences page for current and recent events
- Clean up Quasar description in Mobile Apps page