### PR TITLE
Propose moving 'Contributing' page

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -61,10 +61,6 @@ module.exports = {
             items: [
               { text: 'Spanish', link: '/multilingual/spanish.md' }
             ]
-          },
-          {
-            text: 'Contributing',
-            link: '/contributing/'
           }
         ],
         sidebar: [
@@ -118,7 +114,8 @@ module.exports = {
               '/guide/ecosystem/static-site-generators.md',
               '/guide/ecosystem/build-tools.md',
               '/guide/ecosystem/projects-worth-mentioning.md',
-              '/guide/ecosystem/legacy.md'
+              '/guide/ecosystem/legacy.md',
+              '/guide/ecosystem/contributing.md'
             ]
           }
         ]

--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -38,3 +38,4 @@
 * [Build Tools](./ecosystem/build-tools.md) - Build tools used across Vue ecosystem
 * [Projects worth mentioning](./ecosystem/projects-worth-mentioning.md) - Important Vue projects that don't fit in other categories.
 * [Legacy Packages](./ecosystem/legacy.md) - Outdated or deprecated Vue packages and features
+* [Contributing](./ecosystem/contributing.md) - Notes on contributing to the ecosystem

--- a/docs/guide/ecosystem/contributing.md
+++ b/docs/guide/ecosystem/contributing.md
@@ -2,7 +2,7 @@
 
 ## Contributing
 
-</useful-links-section>
+<useful-links>
 <useful-links-section title="Official links">
 
 - [Join the Vue.js Community!](https://v3.vuejs.org/community/join.html)

--- a/docs/guide/ecosystem/contributing.md
+++ b/docs/guide/ecosystem/contributing.md
@@ -1,8 +1,10 @@
-# How to contribute to the Vue Core and its accompanying ecosystem
+# Contributing
 
-## How to write your own library
+## How to contribute to the Vue Core and its accompanying ecosystem
 
-## Why NOT to write your own library
+### How to write your own library
+
+### Why NOT to write your own library
 
 ::: contribute
 :::

--- a/docs/guide/ecosystem/contributing.md
+++ b/docs/guide/ecosystem/contributing.md
@@ -3,3 +3,6 @@
 ## How to write your own library
 
 ## Why NOT to write your own library
+
+::: contribute
+:::

--- a/docs/guide/ecosystem/contributing.md
+++ b/docs/guide/ecosystem/contributing.md
@@ -5,8 +5,8 @@
 </useful-links-section>
 <useful-links-section title="Official links">
 
-[Join the Vue.js Community!](https://v3.vuejs.org/community/join.html)
-[Vue.js Contributing Guide](https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md)
+- [Join the Vue.js Community!](https://v3.vuejs.org/community/join.html)
+- [Vue.js Contributing Guide](https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md)
 
 </useful-links-section>
 </useful-links>

--- a/docs/guide/ecosystem/contributing.md
+++ b/docs/guide/ecosystem/contributing.md
@@ -1,6 +1,15 @@
 # Contributing
 
-## How to contribute to the Vue Core and its accompanying ecosystem
+## Contributing
+
+</useful-links-section>
+<useful-links-section title="Official links">
+
+[Join the Vue.js Community!](https://v3.vuejs.org/community/join.html)
+[Vue.js Contributing Guide](https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md)
+
+</useful-links-section>
+</useful-links>
 
 ### How to write your own library
 


### PR DESCRIPTION
- Move Contributing page under Ecosystem in Guide instead of top nav

Seems less helpful for it to have current prominent placement when there isn't much there yet