### PR TITLE
Move and update Vue 3 page

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -78,8 +78,7 @@ module.exports = {
               '/guide/community/social-media.md',
               '/guide/community/diversity.md',
               '/guide/community/job-market.md',
-              '/guide/community/adopt-vue-at-work.md',
-              '/guide/community/vue-3.md'
+              '/guide/community/adopt-vue-at-work.md'
             ]
           },
           {
@@ -92,8 +91,9 @@ module.exports = {
               '/guide/learning/courses.md',
               '/guide/learning/books.md',
               '/guide/learning/blogs.md',
-              '/guide/learning/faq.md',
               '/guide/learning/podcasts.md',
+              '/guide/learning/vue-3.md',
+              '/guide/learning/faq.md',
               '/guide/learning/tips-from-mentors.md',
               '/guide/learning/workshops.md'
             ]

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -87,12 +87,12 @@ module.exports = {
             children: [
               '/guide/learning/official-documentation.md',
               '/guide/learning/how-to-learn-vue.md',
+              '/guide/learning/vue-3.md',
               '/guide/learning/learning-platforms.md',
               '/guide/learning/courses.md',
               '/guide/learning/books.md',
               '/guide/learning/blogs.md',
               '/guide/learning/podcasts.md',
-              '/guide/learning/vue-3.md',
               '/guide/learning/faq.md',
               '/guide/learning/tips-from-mentors.md',
               '/guide/learning/workshops.md'

--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -7,17 +7,17 @@
 * [Diversity](./community/diversity.md) - Diversity and inclusion in Vue.js
 * [Job Market](./community/job-market.md) - How to find job with Vue.js and related topics
 * [Adopting Vue at work](./community/adopt-vue-at-work.md) - How to pitch Vue at your workplace
-* [Vue 3](./community/vue-3.md) - Vue 3 learning resources and plugins
 
 ## Learning
 * [Official Documentation](./learning/official-documentation.md) - All the official Vue docs, listed on one place
 * [How to learn Vue](./learning/how-to-learn-vue.md) - Tips on how to learn Vue if coming from other technologies
+* [Vue 3](./community/vue-3.md) - Vue 3 learning resources and plugins
 * [Learning platforms](./learning/learning-platforms.md) - Learning platforms that also offer Vue.js video courses
 * [Video Courses](./learning/courses.md) - Popular Vue video courses
 * [Books](./learning/books.md) - Books about Vue development
 * [Blogs](./learning/blogs.md) - Popular Vue related blogs.
-* [Frequently Asked Questions](./learning/faq.md) - Answers to most common questions asked by Vue developers through chats, forum and other media
 * [Podcasts](./learning/podcasts.md) - Vue podcasts or single episodes talking about Vue
+* [Frequently Asked Questions](./learning/faq.md) - Answers to most common questions asked by Vue developers
 * [Tips from Mentors](./learning/tips-from-mentors.md) - How Vue experts began with Vue, tips on how to learn
 * [Workshops](./learning/workshops.md) - What are Vue workshops and where to find them
 

--- a/docs/guide/learning/vue-3.md
+++ b/docs/guide/learning/vue-3.md
@@ -7,8 +7,8 @@ Vue 3 has arrived!
 <useful-links>
 <useful-links-section title="Official">
 
-* [Vue 2 Composition API Plugin](https://github.com/vuejs/composition-api) - If you are eager to try out the new Composition API in Vue 2.
 * [Migration Guide](https://v3.vuejs.org/guide/migration/introduction.html)
+* [Composition API Plugin for Vue 2](https://github.com/vuejs/composition-api)
 
 </useful-links-section>
 </useful-links>

--- a/docs/guide/learning/vue-3.md
+++ b/docs/guide/learning/vue-3.md
@@ -4,8 +4,6 @@ Vue 3 has arrived!
 
 ## Upgrading
 
-If you are one of those who likes to get their hands dirty and likes digging through source code, here are a few repos that you must check out.
-
 <useful-links>
 <useful-links-section title="Official">
 

--- a/docs/guide/learning/vue-3.md
+++ b/docs/guide/learning/vue-3.md
@@ -1,8 +1,8 @@
-# Vue 3 Related Articles
+# Vue 3
 
-At the time of writing, Vue 3 has still not landed officially, but we do have a publicly available alpha version. More and more people are getting excited about the upcoming release and are sharing their thoughts, findings, and speculations about the changes to come.
+Vue 3 has arrived!
 
-## Official Repositories
+## Upgrading
 
 If you are one of those who likes to get their hands dirty and likes digging through source code, here are a few repos that you must check out.
 
@@ -10,8 +10,7 @@ If you are one of those who likes to get their hands dirty and likes digging thr
 <useful-links-section title="Official">
 
 * [Vue 2 Composition API Plugin](https://github.com/vuejs/composition-api) - If you are eager to try out the new Composition API in Vue 2.
-* [Vue 3 pre-alpha](https://github.com/vuejs/vue-next) - The repo for Vue 3 itself.
-* [Vue RFCs repository](https://github.com/vuejs/rfcs) - The repo with all RFCs. If something is going to be changed, it can most probably be found there.
+* [Migration Guide](https://v3.vuejs.org/guide/migration/introduction.html)
 
 </useful-links-section>
 </useful-links>


### PR DESCRIPTION
Fixes #149

- Move Vue 3 page from Community to Learning section
- Update the title and release info
- Replace `Official Repositories` and link to alpha with `Upgrading` links section